### PR TITLE
Add news carousel to dashboard

### DIFF
--- a/src/components/news/MarketNewsCarousel.tsx
+++ b/src/components/news/MarketNewsCarousel.tsx
@@ -1,0 +1,64 @@
+import { useRef } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { MarketNewsItem } from "@/types/news";
+import { Button } from "@/components/ui/button";
+
+interface MarketNewsCarouselProps {
+  items: MarketNewsItem[];
+}
+
+export function MarketNewsCarousel({ items }: MarketNewsCarouselProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const scroll = (dir: "left" | "right") => {
+    const container = containerRef.current;
+    if (!container) return;
+    const scrollAmount = container.clientWidth;
+    container.scrollBy({
+      left: dir === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  };
+
+  if (!items || items.length === 0) return null;
+
+  return (
+    <div className="relative">
+      <div
+        ref={containerRef}
+        className="flex overflow-x-auto space-x-4 pb-4 snap-x"
+      >
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="min-w-[250px] snap-start bg-card rounded-md p-4 shadow"
+          >
+            <p className="text-sm font-semibold mb-1">{item.headline}</p>
+            <p className="text-xs text-muted-foreground line-clamp-3">
+              {item.summary}
+            </p>
+            <p className="text-xs mt-2 text-muted-foreground">
+              {new Date(item.created_at).toLocaleDateString()}
+            </p>
+          </div>
+        ))}
+      </div>
+      <Button
+        variant="outline"
+        size="icon"
+        className="absolute left-0 top-1/2 -translate-y-1/2"
+        onClick={() => scroll("left")}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="outline"
+        size="icon"
+        className="absolute right-0 top-1/2 -translate-y-1/2"
+        onClick={() => scroll("right")}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/hooks/useMarketNews.ts
+++ b/src/hooks/useMarketNews.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { newsService } from "@/services/newsService";
+import { MarketNewsResponse } from "@/types/news";
+
+export const MARKET_NEWS_KEYS = {
+  all: ["marketNews"] as const,
+  summary: () => [...MARKET_NEWS_KEYS.all, "summary"] as const,
+};
+
+export const useMarketNewsSummary = () => {
+  return useQuery<MarketNewsResponse, Error>({
+    queryKey: MARKET_NEWS_KEYS.summary(),
+    queryFn: newsService.getMarketNewsSummary,
+  });
+};

--- a/src/pages/SignalAnalysisPage.tsx
+++ b/src/pages/SignalAnalysisPage.tsx
@@ -16,6 +16,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useMarketNewsSummary } from "@/hooks/useMarketNews";
+import { MarketNewsCarousel } from "@/components/news/MarketNewsCarousel";
 
 const SignalAnalysisPage: React.FC = () => {
   const {
@@ -36,6 +38,7 @@ const SignalAnalysisPage: React.FC = () => {
 
   const [availableAiModels, setAvailableAiModels] = useState<string[]>([]);
   const [selectedSignal, setSelectedSignal] = useState<SignalData | null>(null);
+  const { data: marketNews } = useMarketNewsSummary();
   // const [searchTerm, setSearchTerm] = useState<string>(q ?? ""); // 삭제: SignalSearchInput이 내부적으로 inputValue 관리
 
   // SignalSearchInput에 전달할 선택된 티커 배열 상태
@@ -235,6 +238,11 @@ const SignalAnalysisPage: React.FC = () => {
 
   return (
     <div className="container mx-auto p-4 md:p-8">
+      {marketNews?.result && (
+        <div className="mb-4">
+          <MarketNewsCarousel items={marketNews.result} />
+        </div>
+      )}
       <div className="flex flex-wrap items-start justify-between gap-2 w-full">
         <div className="flex flex-grow items-end gap-2 sm:flex-nowrap w-full">
           <div className="w-full">

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { MarketNewsResponse } from "@/types/news";
+
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+
+const api = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+export const newsService = {
+  async getMarketNewsSummary(): Promise<MarketNewsResponse> {
+    const response = await api.get<MarketNewsResponse>("/market/news-summary");
+    return response.data;
+  },
+};

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -1,0 +1,14 @@
+export type MarketNewsItem = {
+  ticker: string | null;
+  headline: string;
+  detail_description: string;
+  created_at: string;
+  result_type: "market";
+  id: number;
+  date_yyyymmdd: string;
+  summary: string;
+};
+
+export interface MarketNewsResponse {
+  result: MarketNewsItem[];
+}


### PR DESCRIPTION
## Summary
- add MarketNews types and service
- fetch news in SignalAnalysisPage
- display news items at top of dashboard with a custom carousel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'axios' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684c2b9d2d1483289ece08c8498978ac