### PR TITLE
Refactor search params to context

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import App from "./App";
 import Header from "./components/header";
+import { SignalSearchParamsProvider } from "./hooks/useSignalSearchParams";
 // 쿼리 클라이언트 생성
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,8 +21,10 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <Header />
-        <App />
+        <SignalSearchParamsProvider>
+          <Header />
+          <App />
+        </SignalSearchParamsProvider>
       </BrowserRouter>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>


### PR DESCRIPTION
## Summary
- add SignalSearchParamsProvider and useSignalSearchParams hook to manage query params globally
- wrap application with new provider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852a7a08c90832882e62edeeab23bae