### PR TITLE
Group weekly and daily cards in summary tabs

### DIFF
--- a/src/components/signal/SummaryTabsCard.tsx
+++ b/src/components/signal/SummaryTabsCard.tsx
@@ -1,0 +1,64 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+} from "@/components/ui/card";
+import { WeeklyActionCountCard } from "./WeeklyActionCountCard";
+import { WeeklyPriceMovementCard } from "./WeeklyPriceMovementCard";
+import RecommendationByAiCard from "./RecommendationByAICard";
+import RecommendationCard from "./RecommendationCard";
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+
+const SummaryTabsCard = () => {
+  const { date } = useSignalSearchParams();
+
+  return (
+    <Tabs defaultValue="weekly" className="w-full">
+      <Card className="shadow-none">
+        <CardHeader className="p-0">
+          <TabsList className="w-full">
+            <TabsTrigger value="weekly" className="flex-1">
+              Weekly
+            </TabsTrigger>
+            <TabsTrigger value="today" className="flex-1">
+              Today
+            </TabsTrigger>
+          </TabsList>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <TabsContent value="weekly" className="outline-none">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <WeeklyActionCountCard
+                title="Weekly Top Buy Signals"
+                params={{
+                  action: "Buy",
+                  reference_date: date ?? undefined,
+                }}
+              />
+              <WeeklyPriceMovementCard
+                title="Weekly Top Up Price Movements"
+                params={{
+                  direction: "up",
+                  reference_date: date ?? undefined,
+                }}
+              />
+            </div>
+          </TabsContent>
+          <TabsContent value="today" className="outline-none">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <RecommendationByAiCard title="Today Ai`s Recommendation" />
+              <RecommendationCard
+                title="Today News Recommendation"
+                recommendation="Buy"
+                badgeColor="bg-green-100 text-green-800"
+              />
+            </div>
+          </TabsContent>
+        </CardContent>
+      </Card>
+    </Tabs>
+  );
+};
+
+export default SummaryTabsCard;

--- a/src/pages/SignalAnalysisPage.tsx
+++ b/src/pages/SignalAnalysisPage.tsx
@@ -18,13 +18,10 @@ import {
 import { useMarketNewsSummary } from "@/hooks/useMarketNews";
 import { MarketNewsCarousel } from "@/components/news/MarketNewsCarousel";
 import DateSelectorWrapper from "@/components/signal/DateSelectorWrapper";
-import RecommendationCard from "@/components/signal/RecommendationCard";
-import { WeeklyActionCountCard } from "@/components/signal/WeeklyActionCountCard";
-import { WeeklyPriceMovementCard } from "@/components/signal/WeeklyPriceMovementCard";
 import MarketForCastCard from "@/components/news/MarketForcastCard";
 import { withDateValidation } from "@/components/withDateValidation";
 import { CarouselSkeleton } from "@/components/ui/skeletons";
-import RecommendationByAiCard from "@/components/signal/RecommendationByAICard";
+import SummaryTabsCard from "@/components/signal/SummaryTabsCard";
 
 const SignalAnalysisPage: React.FC = () => {
   const {
@@ -202,27 +199,7 @@ const SignalAnalysisPage: React.FC = () => {
   return (
     <div className="container mx-auto p-4 md:p-8">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
-        <WeeklyActionCountCard
-          title="Weekly Top Buy Signals"
-          params={{
-            action: "Buy",
-            reference_date: date ?? undefined,
-          }}
-        />
-        <WeeklyPriceMovementCard
-          title="Weekly Top Up Price Movements"
-          params={{
-            direction: "up",
-            reference_date: date ?? undefined,
-          }}
-        />
-        <RecommendationByAiCard title="Today Ai`s Recommendation" />
-        <RecommendationCard
-          title="Today News Recommendation"
-          recommendation="Buy"
-          badgeColor="bg-green-100 text-green-800"
-        />
-
+        <SummaryTabsCard />
         <MarketForCastCard title="Today Market Forecast" />
       </div>
       <div className="my-4 flex gap-4 items-center">


### PR DESCRIPTION
## Summary
- add `SummaryTabsCard` component to group weekly and daily info using shadcn tabs
- replace individual cards on SignalAnalysisPage with the new tabbed card

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a2f11cbac8328aa91594794050673