### PR TITLE
Improve AI model filter conditions

### DIFF
--- a/src/components/signal/AiModelFilterPanel.tsx
+++ b/src/components/signal/AiModelFilterPanel.tsx
@@ -6,17 +6,17 @@ import { cn } from "@/lib/utils";
 interface AiModelFilterPanelProps {
   availableModels: string[];
   selectedModels: string[];
+  conditions: ("OR" | "AND")[];
   onModelsChange: (models: string[]) => void;
-  onConditionChange: (value: "OR" | "AND") => void;
-  condition: "OR" | "AND";
+  onConditionChange: (index: number, value: "OR" | "AND") => void;
 }
 
 export function AiModelFilterPanel({
   availableModels,
   selectedModels,
+  conditions,
   onModelsChange,
   onConditionChange,
-  condition,
 }: AiModelFilterPanelProps) {
   const handleModelToggle = (model: string) => {
     const currentIndex = selectedModels.indexOf(model);
@@ -30,39 +30,51 @@ export function AiModelFilterPanel({
     onModelsChange(newSelectedModels);
   };
 
+  const handleConditionToggle = (index: number) => {
+    const current = conditions[index] ?? "OR";
+    onConditionChange(index, current === "OR" ? "AND" : "OR");
+  };
+
   return (
     <>
       <div className="flex flex-wrap items-center">
         <div className="flex items-center gap-2">
-          {availableModels.map((model, index) => (
+          {selectedModels.map((model, index) => (
             <React.Fragment key={model}>
               <Badge
-                key={model}
                 variant="secondary"
                 className={cn(
                   "flex items-center gap-1 cursor-pointer",
-                  selectedModels.includes(model)
-                    ? "bg-blue-500 text-primary-foreground"
-                    : "bg-secondary text-secondary-foreground"
+                  "bg-blue-500 text-primary-foreground"
                 )}
                 onClick={() => handleModelToggle(model)}
               >
                 {model}
               </Badge>
-              {index + 1 < availableModels.length && (
+              {index + 1 < selectedModels.length && (
                 <Button
                   variant="link"
                   size="sm"
-                  onClick={() =>
-                    onConditionChange(condition === "OR" ? "AND" : "OR")
-                  }
+                  onClick={() => handleConditionToggle(index)}
                   className="text-xs text-muted-foreground hover:text-foreground m-0 p-0 px-2 cursor-pointer"
                 >
-                  {condition}
+                  {conditions[index] ?? "OR"}
                 </Button>
               )}
             </React.Fragment>
           ))}
+          {availableModels
+            .filter((m) => !selectedModels.includes(m))
+            .map((model) => (
+              <Badge
+                key={model}
+                variant="secondary"
+                className="flex items-center gap-1 cursor-pointer bg-secondary text-secondary-foreground"
+                onClick={() => handleModelToggle(model)}
+              >
+                {model}
+              </Badge>
+            ))}
         </div>
       </div>
     </>

--- a/src/hooks/useDashboardFilters.ts
+++ b/src/hooks/useDashboardFilters.ts
@@ -43,9 +43,15 @@ export function useDashboardFilters() {
   const [selectedAiModels, setSelectedAiModels] = useState<string[]>(() =>
     getArrayParam(searchParams, "models")
   );
-  const [aiModelFilterCondition, setAiModelFilterCondition] = useState<
-    "OR" | "AND"
-  >(() => (getParam(searchParams, "condition", "OR") === "AND" ? "AND" : "OR"));
+  const [aiModelFilterConditions, setAiModelFilterConditions] = useState<
+    ("OR" | "AND")[]
+  >(() => {
+    const condParam = getParam(searchParams, "condition") ?? "";
+    return condParam
+      .split(",")
+      .filter(Boolean)
+      .map((c) => (c === "AND" ? "AND" : "OR"));
+  });
 
   const updateUrlParams = useCallback(() => {
     const params = new URLSearchParams();
@@ -54,7 +60,8 @@ export function useDashboardFilters() {
     if (globalFilter) params.set("q", globalFilter);
     if (selectedAiModels.length > 0)
       params.set("models", selectedAiModels.join(","));
-    if (aiModelFilterCondition === "AND") params.set("condition", "AND");
+    if (aiModelFilterConditions.length > 0)
+      params.set("condition", aiModelFilterConditions.join(","));
 
     if (params.toString() !== searchParams.toString()) {
       setSearchParams(params, { replace: true });
@@ -64,7 +71,7 @@ export function useDashboardFilters() {
     selectedSignalId,
     globalFilter,
     selectedAiModels,
-    aiModelFilterCondition,
+    aiModelFilterConditions,
     setSearchParams,
     todayString,
     searchParams,
@@ -85,7 +92,7 @@ export function useDashboardFilters() {
     setGlobalFilter,
     selectedAiModels,
     setSelectedAiModels,
-    aiModelFilterCondition,
-    setAiModelFilterCondition,
+    aiModelFilterConditions,
+    setAiModelFilterConditions,
   };
 }


### PR DESCRIPTION
## Summary
- handle multiple filter conditions in `useSignalSearchParams`
- adapt `AiModelFilterPanel` to display condition buttons per selected model
- update signal analysis page to work with condition arrays
- tweak unused dashboard filters hook for new API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e1d0f73c083288c15065d0d18d632