### PR TITLE
Add favorite tickers feature

### DIFF
--- a/src/components/signal/columns.tsx
+++ b/src/components/signal/columns.tsx
@@ -2,7 +2,7 @@
 
 import { ColumnDef } from "@tanstack/react-table";
 import { SignalData } from "../../types/signal";
-import { ArrowUpDown } from "lucide-react";
+import { ArrowUpDown, Star } from "lucide-react";
 import { Button } from "@/components/ui/button"; // Shadcn UI의 Button 임포트 경로 확인 필요
 import { Badge } from "@/components/ui/badge"; // Shadcn UI의 Badge 임포트 경로 확인 필요
 import { cn } from "@/lib/utils";
@@ -16,7 +16,35 @@ const formatCurrency = (amount: number | undefined | null) => {
   }).format(amount);
 };
 
-export const columns: ColumnDef<SignalData>[] = [
+export const createColumns = (
+  favorites: string[],
+  toggleFavorite: (ticker: string) => void
+): ColumnDef<SignalData>[] => [
+  {
+    id: "favorite",
+    header: "",
+    cell: ({ row }) => {
+      const ticker = row.original.signal.ticker;
+      const isFav = favorites.includes(ticker);
+      return (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleFavorite(ticker);
+          }}
+          className="cursor-pointer"
+        >
+          <Star
+            className="h-4 w-4"
+            fill={isFav ? "#facc15" : "none"}
+            stroke={isFav ? "#facc15" : "currentColor"}
+          />
+        </button>
+      );
+    },
+    enableSorting: false,
+    enableHiding: false,
+  },
   {
     accessorKey: "signal.ticker",
     header: ({ column }) => {

--- a/src/hooks/useFavoriteTickers.ts
+++ b/src/hooks/useFavoriteTickers.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "favoriteTickers";
+
+export function useFavoriteTickers() {
+  const [favorites, setFavorites] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? (JSON.parse(stored) as string[]) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+    } catch {
+      // ignore write errors
+    }
+  }, [favorites]);
+
+  const toggleFavorite = (ticker: string) => {
+    setFavorites((prev) =>
+      prev.includes(ticker)
+        ? prev.filter((t) => t !== ticker)
+        : [...prev, ticker]
+    );
+  };
+
+  return { favorites, toggleFavorite };
+}


### PR DESCRIPTION
## Summary
- allow starring tickers in the signal table
- persist favorites in localStorage via a new hook
- show starred rows first

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e7ec4f19c8328ac9d035e7a23cefe