### PR TITLE
Add Next-style Tailwind setup

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,81 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-family)"],
+      },
+      borderRadius: {
+        sm: "var(--radius-sm)",
+        md: "var(--radius-md)",
+        lg: "var(--radius-lg)",
+        xl: "var(--radius-xl)",
+      },
+      colors: {
+        border: "var(--color-border)",
+        input: "var(--color-input)",
+        ring: "var(--color-ring)",
+        background: "var(--color-background)",
+        foreground: "var(--color-foreground)",
+        card: {
+          DEFAULT: "var(--color-card)",
+          foreground: "var(--color-card-foreground)",
+        },
+        popover: {
+          DEFAULT: "var(--color-popover)",
+          foreground: "var(--color-popover-foreground)",
+        },
+        primary: {
+          DEFAULT: "var(--color-primary)",
+          foreground: "var(--color-primary-foreground)",
+        },
+        secondary: {
+          DEFAULT: "var(--color-secondary)",
+          foreground: "var(--color-secondary-foreground)",
+        },
+        muted: {
+          DEFAULT: "var(--color-muted)",
+          foreground: "var(--color-muted-foreground)",
+        },
+        accent: {
+          DEFAULT: "var(--color-accent)",
+          foreground: "var(--color-accent-foreground)",
+        },
+        destructive: "var(--color-destructive)",
+        chart1: "var(--color-chart-1)",
+        chart2: "var(--color-chart-2)",
+        chart3: "var(--color-chart-3)",
+        chart4: "var(--color-chart-4)",
+        chart5: "var(--color-chart-5)",
+        sidebar: {
+          DEFAULT: "var(--color-sidebar)",
+          foreground: "var(--color-sidebar-foreground)",
+          primary: "var(--color-sidebar-primary)",
+          primaryForeground: "var(--color-sidebar-primary-foreground)",
+          accent: "var(--color-sidebar-accent)",
+          accentForeground: "var(--color-sidebar-accent-foreground)",
+          border: "var(--color-sidebar-border)",
+          ring: "var(--color-sidebar-ring)",
+        },
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react()],
   resolve: {
     alias: {
       "@": resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- create `tailwind.config.ts` for Next.js with project colors and fonts
- add `postcss.config.cjs`
- remove Vite Tailwind plugin

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm build` *(fails: missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_685f68b9b93483288db18b12e6181b29