### PR TITLE
Use process.env for API urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_API_BASE_URL=https://api.example.com
+NEXT_PUBLIC_API_LOCAL_URL=http://localhost:8000
+NEXT_PUBLIC_SEO_API_BASE_URL=https://api.example.com

--- a/README.md
+++ b/README.md
@@ -46,8 +46,20 @@ Follow these steps to get started with the react-vite-ui template:
 4. Start the development server:
 
    ```bash
-   pnpm dev
-   ```
+  pnpm dev
+  ```
+
+## 🌐 Environment Variables
+
+Create a `.env` file in the project root with the following keys:
+
+```bash
+NEXT_PUBLIC_API_BASE_URL=<production api url>
+NEXT_PUBLIC_API_LOCAL_URL=<local api url>
+NEXT_PUBLIC_SEO_API_BASE_URL=<seo api url>
+```
+
+These variables are used by the service layer and SEO utilities.
 
 ## 📜 Available Scripts
 

--- a/seo.config.ts
+++ b/seo.config.ts
@@ -1,7 +1,8 @@
 export const siteConfig = {
   siteName: "SAPM",
   baseUrl: "https://example.com",
-  apiBaseUrl: import.meta.env.SEO_API_BASE_URL ?? "https://api.example.com",
+  apiBaseUrl:
+    process.env.NEXT_PUBLIC_SEO_API_BASE_URL ?? "https://api.example.com",
   defaultImage: "/default-og.png",
 };
 

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -10,9 +10,10 @@ import {
   NewsRecommendationsResponse,
 } from "@/types/news";
 
-const API_BASE_URL = import.meta.env.DEV
-  ? import.meta.env.VITE_API_LOCAL_URL
-  : import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+const API_BASE_URL =
+  process.env.NODE_ENV === "development"
+    ? process.env.NEXT_PUBLIC_API_LOCAL_URL
+    : process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
 
 const api = axios.create({
   baseURL: API_BASE_URL,

--- a/src/services/signalService.ts
+++ b/src/services/signalService.ts
@@ -6,9 +6,10 @@ import {
 } from "../types/signal";
 
 // API 기본 URL 설정 (기존 tickerService.ts와 동일하게 환경 변수 사용)
-const API_BASE_URL = import.meta.env.DEV
-  ? import.meta.env.VITE_API_LOCAL_URL
-  : import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+const API_BASE_URL =
+  process.env.NODE_ENV === "development"
+    ? process.env.NEXT_PUBLIC_API_LOCAL_URL
+    : process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
 
 // Axios 인스턴스 생성
 const api = axios.create({

--- a/src/services/tickerService.ts
+++ b/src/services/tickerService.ts
@@ -10,9 +10,10 @@ import {
 } from "../types/ticker";
 
 // API 기본 URL 설정
-const API_BASE_URL = import.meta.env.DEV
-  ? import.meta.env.VITE_API_LOCAL_URL
-  : import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+const API_BASE_URL =
+  process.env.NODE_ENV === "development"
+    ? process.env.NEXT_PUBLIC_API_LOCAL_URL
+    : process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
 
 // Axios 인스턴스 생성
 const api = axios.create({


### PR DESCRIPTION
## Summary
- switch SEO config and services to use `process.env` variables
- add sample `.env` file
- document env vars in README

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860902599e483289521d21d77a0037f