### PR TITLE
Move React pages to Next.js App Router

### DIFF
--- a/next_migration/src/app/about/page.tsx
+++ b/next_migration/src/app/about/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function About() {
+  return (
+    <div>
+      <h1>소개</h1>
+      <p>이 프로젝트는 React Router와 TanStack Query를 사용합니다.</p>
+    </div>
+  );
+}

--- a/next_migration/src/app/dashboard/page.tsx
+++ b/next_migration/src/app/dashboard/page.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { format as formatDate } from "date-fns";
+import { SignalData } from "@/types/signal";
+import { useSignalDataByDate } from "@/hooks/useSignal";
+
+import { createColumns } from "@/components/signal/columns";
+import { useFavoriteTickers } from "@/hooks/useFavoriteTickers";
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+import { AiModelFilterPanel } from "@/components/signal/AiModelFilterPanel";
+import { SignalListWrapper } from "@/components/signal/SignalListWrapper";
+import { SignalDetailSection } from "@/components/signal/SignalDetailSection";
+import SignalSearchInput from "@/components/signal/SignalSearchInput";
+import { Badge } from "@/components/ui/badge";
+import { InfoIcon, XIcon } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useMarketNewsSummary } from "@/hooks/useMarketNews";
+import { MarketNewsCarousel } from "@/components/news/MarketNewsCarousel";
+import DateSelectorWrapper from "@/components/signal/DateSelectorWrapper";
+import MarketForCastCard from "@/components/news/MarketForcastCard";
+import { withDateValidation } from "@/components/withDateValidation";
+import { CarouselSkeleton } from "@/components/ui/skeletons";
+import RecommendationByAiCard from "@/components/signal/RecommendationByAICard";
+import { WeeklyPriceMovementCard } from "@/components/signal/WeeklyPriceMovementCard";
+import RecommendationCard from "@/components/signal/RecommendationCard";
+import { WeeklyActionCountCard } from "@/components/signal/WeeklyActionCountCard";
+import SummaryTabsCard from "@/components/signal/SummaryTabsCard";
+import HeroSection from "@/components/dashboard/HeroSection";
+import DashboardFooter from "@/components/dashboard/DashboardFooter";
+import { SeoHelmet } from "@/components/seo/SeoHelmet";
+
+const SignalAnalysisPage: React.FC = () => {
+  const {
+    date,
+    q,
+    signalId,
+    models: selectedAiModels,
+    conditions: aiModelFilterConditions,
+    page, // 페이지 인덱스 추가
+    pageSize, // 페이지 크기 추가
+    setParams,
+  } = useSignalSearchParams();
+
+  const todayString = formatDate(new Date(), "yyyy-MM-dd");
+  const submittedDate = date ?? todayString;
+
+  const [availableAiModels, setAvailableAiModels] = useState<string[]>([]);
+  const { favorites, toggleFavorite } = useFavoriteTickers();
+  const { data: marketNews, isLoading: isMarketNewsLoading } =
+    useMarketNewsSummary({ news_type: "market", news_date: submittedDate });
+
+  const [currentSelectedTickersArray, setCurrentSelectedTickersArray] =
+    useState<string[]>([]);
+
+  // URL의 q 파라미터가 변경되면 currentSelectedTickersArray를 업데이트
+  useEffect(() => {
+    const tickersFromQ = q
+      ? q
+          .split(",")
+          .map((t) => t.trim())
+          .filter((t) => t.length > 0)
+      : [];
+    setCurrentSelectedTickersArray(tickersFromQ);
+  }, [q]);
+
+  const {
+    data: signalApiResponse,
+    isLoading,
+    error,
+    refetch,
+  } = useSignalDataByDate(submittedDate, {
+    enabled: !!submittedDate,
+    select(data) {
+      return {
+        date: data.date,
+        signals: data.signals,
+      };
+    },
+  });
+
+  // SignalSearchInput에 제공할 전체 티커 목록 (중복 제거)
+  const allAvailableTickersForSearch = useMemo(() => {
+    if (!signalApiResponse?.signals) return [];
+    return [
+      ...new Set(
+        signalApiResponse.signals
+          .map((s) => s.signal.ticker)
+          .filter(Boolean) as string[]
+      ),
+    ].sort();
+  }, [signalApiResponse?.signals]);
+
+  useEffect(() => {
+    if (submittedDate) {
+      refetch();
+    }
+  }, [submittedDate, refetch]);
+
+  useEffect(() => {
+    if (signalApiResponse?.signals) {
+      const models = Array.from(
+        new Set(
+          signalApiResponse.signals
+            .map((s) => s.signal.ai_model)
+            .filter(Boolean) as string[]
+        )
+      ).sort();
+      setAvailableAiModels(models);
+    }
+  }, [signalApiResponse?.signals]);
+
+  const selectedSignal = useMemo(() => {
+    if (!signalApiResponse?.signals || !signalId) return null;
+    const [symbol, model] = signalId.split("_");
+    return signalApiResponse.signals.find(
+      (s) => s.signal.ticker === symbol && s.signal.ai_model === model,
+    );
+  }, [signalId, signalApiResponse?.signals]);
+
+  const seoTitle = selectedSignal
+    ? `${selectedSignal.signal.ticker} ${selectedSignal.signal.ai_model}`
+    : "Dashboard";
+  const seoDesc = selectedSignal?.signal.report_summary ?? "Signal dashboard";
+
+  const handleRowClick = (signal: SignalData) => {
+    const id = `${signal.signal.ticker}_${signal.signal.ai_model}`;
+    setParams({
+      signalId: id, // 행 클릭 시 해당 시그널 ID 설정
+    });
+  };
+
+  // SignalSearchInput에서 선택된 티커가 변경될 때 호출
+  const handleSelectedTickersChange = (newSelectedTickers: string[]) => {
+    // setCurrentSelectedTickersArray(newSelectedTickers); // useEffect[q]가 이 역할을 함
+    const newQ =
+      newSelectedTickers.length > 0 ? newSelectedTickers.join(",") : null;
+    setParams({
+      q: newQ, // 새로운 티커 문자열로 q 업데이트
+      signalId: null, // 티커 검색 변경 시 특정 시그널 선택은 초기화
+      page: "0",
+    });
+  };
+
+  const filteredSignals = useMemo(() => {
+    if (!signalApiResponse?.signals) return [];
+    let signalsToFilter = signalApiResponse.signals;
+
+    const searchTickersArray = currentSelectedTickersArray; // 이미 q로부터 파싱된 배열 사용
+
+    if (searchTickersArray.length > 0) {
+      signalsToFilter = signalsToFilter.filter((item) => {
+        const ticker = item.signal.ticker?.toLowerCase();
+        if (!ticker) return false;
+        return searchTickersArray.some((st) =>
+          ticker.includes(st.toLowerCase())
+        );
+      });
+    }
+
+    if (selectedAiModels.length > 0) {
+      if (aiModelFilterConditions.every((c) => c === "OR")) {
+        signalsToFilter = signalsToFilter.filter((item) => {
+          const model = item.signal.ai_model;
+          return model && selectedAiModels.includes(model);
+        });
+      } else if (aiModelFilterConditions.every((c) => c === "AND")) {
+        const signalsByTicker: Record<
+          string,
+          { models: Set<string>; items: SignalData[] }
+        > = {};
+        signalsToFilter.forEach((item) => {
+          const ticker = item.signal.ticker;
+          const model = item.signal.ai_model;
+          if (!ticker) return;
+          if (!signalsByTicker[ticker]) {
+            signalsByTicker[ticker] = { models: new Set(), items: [] };
+          }
+          if (model) {
+            signalsByTicker[ticker].models.add(model);
+          }
+          signalsByTicker[ticker].items.push(item);
+        });
+
+        const tickersSatisfyingAndCondition = Object.keys(
+          signalsByTicker
+        ).filter((ticker) => {
+          const tickerModels = signalsByTicker[ticker].models;
+          return selectedAiModels.every((m) => tickerModels.has(m));
+        });
+
+        let resultSignals: SignalData[] = [];
+        tickersSatisfyingAndCondition.forEach((ticker) => {
+          resultSignals = resultSignals.concat(signalsByTicker[ticker].items);
+        });
+
+        signalsToFilter = resultSignals.filter((item) => {
+          const model = item.signal.ai_model;
+          return model && selectedAiModels.includes(model);
+        });
+      } else {
+        const signalsByTicker: Record<
+          string,
+          { models: Set<string>; items: SignalData[] }
+        > = {};
+        signalsToFilter.forEach((item) => {
+          const ticker = item.signal.ticker;
+          const model = item.signal.ai_model;
+          if (!ticker) return;
+          if (!signalsByTicker[ticker]) {
+            signalsByTicker[ticker] = { models: new Set(), items: [] };
+          }
+          if (model) {
+            signalsByTicker[ticker].models.add(model);
+          }
+          signalsByTicker[ticker].items.push(item);
+        });
+
+        let resultSignals: SignalData[] = [];
+        Object.entries(signalsByTicker).forEach(([, info]) => {
+          const tickerModels = info.models;
+          const presence = selectedAiModels.map((m) => tickerModels.has(m));
+          let acc = presence[0];
+          for (let i = 1; i < presence.length; i++) {
+            const cond =
+              aiModelFilterConditions[i - 1] ??
+              aiModelFilterConditions[0] ??
+              "OR";
+            if (cond === "OR") {
+              acc = acc || presence[i];
+            } else {
+              acc = acc && presence[i];
+            }
+          }
+          if (acc) {
+            resultSignals = resultSignals.concat(
+              info.items.filter((it) =>
+                selectedAiModels.includes(it.signal.ai_model ?? "")
+              )
+            );
+          }
+        });
+
+        signalsToFilter = resultSignals;
+      }
+    }
+    return signalsToFilter.map((signalData) => ({
+      ...signalData,
+      signal: {
+        ...signalData.signal,
+        favorite: favorites.includes(signalData.signal.ticker) ? 1 : 0,
+      },
+    }));
+  }, [
+    signalApiResponse?.signals,
+    currentSelectedTickersArray,
+    selectedAiModels,
+    aiModelFilterConditions,
+    favorites,
+  ]);
+
+  const sortedSignals = useMemo(() => {
+    const a = [...filteredSignals].sort((a, b) => {
+      return (
+        a.signal.favorite - b.signal.favorite ||
+        a.signal.ticker.localeCompare(b.signal.ticker)
+      );
+    });
+
+    return a;
+  }, [filteredSignals]);
+
+  const columns = useMemo(
+    () => createColumns(favorites, toggleFavorite),
+    [favorites, toggleFavorite]
+  );
+
+  const handlePaginationChange = (
+    newPageIndex: number,
+    newPageSize: number
+  ) => {
+    setParams({
+      page: newPageIndex.toString(),
+      pageSize: newPageSize.toString(),
+    });
+  };
+
+  return (
+    <>
+      <SeoHelmet title={seoTitle} description={seoDesc} />
+      <HeroSection />
+      <div className="mx-auto p-4 md:p-8 max-w-[1500px]">
+        <div className="grid gap-4 mb-4 grid-cols-[3fr_4fr_4fr] max-lg:grid-cols-1">
+          <MarketForCastCard title="Today Market Forecast" />
+          <SummaryTabsCard
+            tabs={[
+              {
+                label: "Weekly Top Signals",
+                value: "signals",
+                component: (
+                  <WeeklyActionCountCard
+                    title="Weekly Top Buy Signals"
+                    params={{
+                      action: "Buy",
+                      reference_date: date ?? undefined,
+                    }}
+                  />
+                ),
+              },
+              {
+                label: "Weekly Top Price Movements",
+                value: "price",
+                component: (
+                  <WeeklyPriceMovementCard
+                    title="Weekly Top Up Price Movements"
+                    params={{
+                      direction: "up",
+                      reference_date: date ?? undefined,
+                    }}
+                  />
+                ),
+              },
+            ]}
+          />
+          <SummaryTabsCard
+            tabs={[
+              {
+                label: "AI Recommendations",
+                value: "ai",
+                component: (
+                  <RecommendationByAiCard title="Today Ai's Recommendation" />
+                ),
+              },
+              {
+                label: "News Recommendations",
+                value: "news",
+                component: (
+                  <RecommendationCard
+                    title="Today News Recommendation"
+                    recommendation="Buy"
+                    badgeColor="bg-green-100 text-green-800"
+                  />
+                ),
+              },
+            ]}
+          />
+        </div>
+        <div className="my-4 flex gap-4 items-center">
+          <div className="w-full h-full grid grid-cols-[1fr_auto] gap-4 max-w-full max-sm:flex max-sm:flex-col">
+            <DateSelectorWrapper popover={false} />
+            <div className="w-full grid grid-cols-1 h-full">
+              {!isMarketNewsLoading ? (
+                <MarketNewsCarousel items={marketNews?.result ?? []} />
+              ) : (
+                <CarouselSkeleton itemCount={10} />
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-start justify-between gap-2 w-full">
+          <div className="flex flex-grow items-end gap-2 sm:flex-nowrap w-full">
+            <div className="w-full">
+              <SignalSearchInput
+                selectedTickers={currentSelectedTickersArray}
+                onSelectedTickersChange={handleSelectedTickersChange}
+                availableTickers={allAvailableTickersForSearch}
+                placeholder="티커 선택"
+              />
+              {currentSelectedTickersArray.length > 0 && (
+                <div className="flex gap-1 py-2 max-w-[400px] flex-wrap">
+                  {currentSelectedTickersArray.map((ticker) => (
+                    <Badge className="text-xs" key={ticker}>
+                      {ticker}
+                      <button
+                        onClick={() =>
+                          handleSelectedTickersChange(
+                            currentSelectedTickersArray.filter(
+                              (t) => t !== ticker
+                            )
+                          )
+                        }
+                      >
+                        <XIcon size={12} className="cursor-pointer text-sm" />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="w-full flex flex-wrap items-start justify-between gap-2 pb-4">
+          <div className="flex items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InfoIcon className="w-4 h-4 cursor-help" />
+              </TooltipTrigger>
+              <TooltipContent className="ml-2">
+                <p>
+                  LLM 모델 필터링 방식을 선택합니다. <br />
+                  <strong>OR:</strong> 선택된 모델 중 하나라도 포함된 시그널을
+                  표시합니다. <br />
+                  <strong>AND:</strong> 선택된 모든 모델을 포함하는 시그널을
+                  표시합니다.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+            <AiModelFilterPanel
+              availableModels={availableAiModels}
+              selectedModels={selectedAiModels}
+              conditions={aiModelFilterConditions}
+              onModelsChange={(models) =>
+                setParams({
+                  models,
+                  page: "0",
+                })
+              }
+              onConditionChange={(idx, value) =>
+                setParams({
+                  conditions: aiModelFilterConditions
+                    .map((c, i) => (i === idx ? value : c))
+                    .slice(0, Math.max(0, selectedAiModels.length - 1)),
+                  page: "0",
+                })
+              }
+            />
+          </div>
+        </div>
+
+        <SignalListWrapper
+          submittedDate={submittedDate}
+          columns={columns}
+          data={sortedSignals}
+          onRowClick={handleRowClick}
+          isLoading={isLoading}
+          pagination={{
+            pageIndex: +`${page}`,
+            pageSize: +`${pageSize}`,
+          }}
+          onPaginationChange={handlePaginationChange}
+        />
+
+        <SignalDetailSection
+          isLoading={isLoading}
+          hasSignals={
+            !!signalApiResponse?.signals && signalApiResponse.signals.length > 0
+          }
+          error={error}
+        />
+      </div>
+      <DashboardFooter />
+    </>
+  );
+};
+
+export default withDateValidation(SignalAnalysisPage);

--- a/next_migration/src/app/dates/page.tsx
+++ b/next_migration/src/app/dates/page.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { format } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { useTickerChanges, useTickers } from "@/hooks/useTicker";
+import { TickerChangeResponse } from "@/types/ticker";
+import { cn } from "@/lib/utils";
+
+const TickerDates = () => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const setSearchParams = useCallback((params: { symbol?: string; dates?: string }) => {
+    const newParams = new URLSearchParams(searchParams.toString());
+    if (params.symbol) {
+      newParams.set('symbol', params.symbol);
+    } else {
+      newParams.delete('symbol');
+    }
+    if (params.dates) {
+      newParams.set('dates', params.dates);
+    } else {
+      newParams.delete('dates');
+    }
+    router.push('?' + newParams.toString());
+  }, [searchParams, router]);
+  const [selectedSymbol, setSelectedSymbol] = useState<string>("");
+  const [selectedDates, setSelectedDates] = useState<Date[]>([]);
+  const [formattedDates, setFormattedDates] = useState<string[]>([]);
+
+  // 티커 목록 조회
+  const { data: tickers, isLoading: isLoadingTickers } = useTickers();
+
+  // URL에서 데이터 추출
+  useEffect(() => {
+    const symbol = searchParams.get("symbol");
+    const dates = searchParams.get("dates");
+
+    if (symbol) {
+      setSelectedSymbol(symbol);
+    }
+
+    if (dates) {
+      try {
+        const parsedDates = JSON.parse(dates) as string[];
+        setFormattedDates(parsedDates);
+        setSelectedDates(parsedDates.map((dateStr) => new Date(dateStr)));
+      } catch (error) {
+        console.error("날짜 파싱 오류:", error);
+      }
+    }
+  }, [searchParams]);
+
+  // 날짜 배열 업데이트 시 URL 업데이트
+  useEffect(() => {
+    if (formattedDates.length > 0 || selectedSymbol) {
+      const params: { symbol?: string; dates?: string } = {};
+
+      if (selectedSymbol) {
+        params.symbol = selectedSymbol;
+      }
+
+      if (formattedDates.length > 0) {
+        params.dates = JSON.stringify(formattedDates);
+      }
+
+      setSearchParams(params);
+    }
+  }, [formattedDates, selectedSymbol, setSearchParams]);
+
+  // 변화율 데이터 조회
+  const { data: tickerChanges, isLoading: isLoadingChanges } = useTickerChanges(
+    selectedSymbol && formattedDates.length > 0
+      ? { symbol: selectedSymbol, dates: formattedDates }
+      : undefined
+  );
+
+  // 날짜 선택 처리
+  const handleDateSelect = (dates: Date[] | undefined) => {
+    if (!dates) return;
+
+    // Calendar returns the complete array of selected dates
+    // So we can just update our state with the new array
+    setSelectedDates(dates);
+    setFormattedDates(dates.map((date) => format(date, "yyyy-MM-dd")));
+  };
+
+  // 심볼 선택 처리
+  const handleSymbolSelect = (value: string) => {
+    setSelectedSymbol(value);
+  };
+
+  // 차트 데이터 포맷팅
+  const chartData =
+    tickerChanges?.map((item: TickerChangeResponse) => ({
+      date: item.date,
+      price: item.price,
+      changePercentage: item.change_percentage,
+    })) || [];
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6">티커 날짜별 변화율</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+        {/* 티커 선택 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>티커 선택</CardTitle>
+            <CardDescription>분석할 주식 티커를 선택하세요</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Select value={selectedSymbol} onValueChange={handleSymbolSelect}>
+              <SelectTrigger>
+                <SelectValue placeholder="티커 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {isLoadingTickers ? (
+                  <SelectItem value="loading" disabled>
+                    로딩 중...
+                  </SelectItem>
+                ) : (
+                  tickers?.map((ticker) => (
+                    <SelectItem key={ticker.id} value={ticker.symbol}>
+                      {ticker.symbol} - {ticker.name}
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </CardContent>
+        </Card>
+
+        {/* 날짜 선택 */}
+        <Card className="col-span-1 md:col-span-2">
+          <CardHeader>
+            <CardTitle>날짜 선택</CardTitle>
+            <CardDescription>
+              분석할 날짜들을 선택하세요 (최대 5개)
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="w-full justify-start text-left font-normal"
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {selectedDates.length > 0
+                    ? `${selectedDates.length}개 날짜 선택됨`
+                    : "날짜 선택하기"}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="multiple"
+                  selected={selectedDates}
+                  onSelect={(date) => handleDateSelect(date)}
+                  disabled={(date) =>
+                    selectedDates.length >= 5 &&
+                    !selectedDates.some(
+                      (selectedDate) =>
+                        format(selectedDate, "yyyy-MM-dd") ===
+                        format(date, "yyyy-MM-dd")
+                    )
+                  }
+                />
+              </PopoverContent>
+            </Popover>
+
+            {/* 선택된 날짜 표시 */}
+            <div className="mt-4 flex flex-wrap gap-2">
+              {selectedDates.map((date, index) => (
+                <div
+                  key={index}
+                  className="bg-primary/10 text-primary rounded-md px-2 py-1 text-sm flex items-center"
+                >
+                  {format(date, "yyyy-MM-dd")}
+                  <button
+                    className="ml-2 text-red-500 hover:text-red-700"
+                    onClick={() => {
+                      const dateStr = format(date, "yyyy-MM-dd");
+                      setFormattedDates(
+                        formattedDates.filter((d) => d !== dateStr)
+                      );
+                      setSelectedDates(
+                        selectedDates.filter((_, i) => i !== index)
+                      );
+                    }}
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 요약 정보 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>요약 정보</CardTitle>
+            <CardDescription>선택된 기간 동안의 변화</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isLoadingChanges ? (
+              <div>데이터 로딩 중...</div>
+            ) : tickerChanges && tickerChanges.length > 0 ? (
+              <div className="space-y-2">
+                <div>
+                  <span className="font-semibold">티커:</span> {selectedSymbol}
+                </div>
+                <div>
+                  <span className="font-semibold">선택 날짜:</span>{" "}
+                  {formattedDates.length}개
+                </div>
+                <div>
+                  <span className="font-semibold">최대 변화율:</span>{" "}
+                  {Math.max(
+                    ...tickerChanges.map((item) => item.change_percentage)
+                  )?.toFixed(2)}
+                  %
+                </div>
+                <div>
+                  <span className="font-semibold">최소 변화율:</span>{" "}
+                  {Math.min(
+                    ...tickerChanges.map((item) => item.change_percentage)
+                  )?.toFixed(2)}
+                  %
+                </div>
+              </div>
+            ) : (
+              <div>데이터가 없습니다</div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 차트 표시 */}
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>가격 및 변화율 추이</CardTitle>
+          <CardDescription>
+            선택된 날짜 간의 가격 및 변화율 비교
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-80">
+          {isLoadingChanges ? (
+            <div className="flex h-full items-center justify-center">
+              데이터 로딩 중...
+            </div>
+          ) : tickerChanges && tickerChanges.length > 0 ? (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={chartData}
+                margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis yAxisId="left" />
+                <YAxis yAxisId="right" orientation="right" />
+                <Tooltip />
+                <Legend />
+                <Line
+                  yAxisId="left"
+                  type="monotone"
+                  dataKey="price"
+                  name="가격"
+                  stroke="#8884d8"
+                  activeDot={{ r: 8 }}
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="changePercentage"
+                  name="변화율 (%)"
+                  stroke="#82ca9d"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              {selectedSymbol && formattedDates.length > 0
+                ? "해당 날짜에 대한 데이터가 없습니다."
+                : "티커와 날짜를 선택하세요."}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 상세 데이터 테이블 */}
+      {tickerChanges && tickerChanges.length > 0 && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>상세 데이터</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="border-b">
+                    <th className="px-4 py-2 text-left">날짜</th>
+                    <th className="px-4 py-2 text-left">가격</th>
+                    <th className="px-4 py-2 text-left">변화율</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {tickerChanges.map(
+                    (item: TickerChangeResponse, index: number) => (
+                      <tr
+                        key={index}
+                        className={cn(
+                          "border-b",
+                          index % 2 === 0 ? "bg-muted/50" : ""
+                        )}
+                      >
+                        <td className="px-4 py-2">{item.date}</td>
+                        <td className="px-4 py-2">${item.price?.toFixed(2)}</td>
+                        <td
+                          className={cn(
+                            "px-4 py-2",
+                            item.change_percentage > 0
+                              ? "text-green-600"
+                              : "text-red-600"
+                          )}
+                        >
+                          {item.change_percentage > 0 ? "+" : ""}
+                          {item.change_percentage?.toFixed(2)}%
+                        </td>
+                      </tr>
+                    )
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default TickerDates;

--- a/next_migration/src/app/not-found.tsx
+++ b/next_migration/src/app/not-found.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div>
+      <h1>404 - 페이지를 찾을 수 없습니다</h1>
+      <Link href="/">홈으로 돌아가기</Link>
+    </div>
+  );
+}

--- a/next_migration/src/app/page.tsx
+++ b/next_migration/src/app/page.tsx
@@ -1,9 +1,154 @@
-export default function Main() {
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  useTickers,
+  useTickerBySymbol,
+  useTickerByDate,
+} from "@/hooks/useTicker";
+import { Ticker } from "@/types/ticker";
+import { useRouter } from "next/navigation";
+
+function Home() {
+  const [selectedSymbol, setSelectedSymbol] = useState<string>("");
+  const [selectedDate, setSelectedDate] = useState<string>("");
+
+  // 모든 티커 조회
+  const { data: tickers, isLoading, error } = useTickers();
+
+  // 선택된 심볼의 티커 조회
+  const { data: tickerDetails, isLoading: isLoadingDetail } =
+    useTickerBySymbol(selectedSymbol);
+
+  // 특정 날짜의 티커 조회
+  const { data: dateTickerData, isLoading: isLoadingDateData } =
+    useTickerByDate(selectedSymbol, selectedDate);
+
+  const router = useRouter();
+
+  useEffect(() => {
+    const today = new Date();
+    const formattedDate = today.toISOString().split("T")[0]; // YYYY-MM-DD 형식
+    router.push(`/dashboard?date=${formattedDate}`);
+  }, [router]);
+
+  if (isLoading) return <div>티커 목록을 로딩 중입니다...</div>;
+  if (error) return <div>에러 발생: {(error as Error).message}</div>;
+
   return (
-    <div className='container mx-auto max-w-[784px]'>
-      <main className='relative z-10 flex flex-col items-center justify-center px-4 py-6'>
-        <div className='flex w-full flex-col gap-2'></div>
-      </main>
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">주식 티커 정보</h1>
+
+      {/* 티커 목록 */}
+      <div className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">티커 목록</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {tickers?.map((ticker: Ticker) => (
+            <div
+              key={ticker.id}
+              className="border p-4 rounded cursor-pointer hover:bg-gray-100"
+              onClick={() => setSelectedSymbol(ticker.symbol)}
+            >
+              <h3 className="font-bold">{ticker.symbol}</h3>
+              <p>{ticker.name}</p>
+              <p className="font-semibold">${ticker.price.toFixed(2)}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 선택된 티커 상세 정보 */}
+      {selectedSymbol && (
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold mb-2">티커 상세 정보</h2>
+          {isLoadingDetail ? (
+            <div>상세 정보 로딩 중...</div>
+          ) : tickerDetails ? (
+            <div className="border p-4 rounded">
+              {tickerDetails.map((tickerDetail) => (
+                <>
+                  <h3 className="text-lg font-bold" key={tickerDetail.id}>
+                    {tickerDetail.symbol} - {tickerDetail.name}
+                  </h3>
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mt-2">
+                    <div>
+                      <span className="font-semibold">현재가:</span> $
+                      {tickerDetail.price.toFixed(2)}
+                    </div>
+                    {tickerDetail.open_price && (
+                      <div>
+                        <span className="font-semibold">시가:</span> $
+                        {tickerDetail.open_price.toFixed(2)}
+                      </div>
+                    )}
+                    {tickerDetail.high_price && (
+                      <div>
+                        <span className="font-semibold">고가:</span> $
+                        {tickerDetail.high_price.toFixed(2)}
+                      </div>
+                    )}
+                    {tickerDetail.low_price && (
+                      <div>
+                        <span className="font-semibold">저가:</span> $
+                        {tickerDetail.low_price.toFixed(2)}
+                      </div>
+                    )}
+                    {tickerDetail.close_price && (
+                      <div>
+                        <span className="font-semibold">종가:</span> $
+                        {tickerDetail.close_price.toFixed(2)}
+                      </div>
+                    )}
+                    {tickerDetail.volume && (
+                      <div>
+                        <span className="font-semibold">거래량:</span>{" "}
+                        {tickerDetail.volume.toLocaleString()}
+                      </div>
+                    )}
+                  </div>
+                </>
+              ))}
+
+              {/* 날짜 선택 */}
+              <div className="mt-4">
+                <label className="block mb-2">특정 날짜 데이터 조회:</label>
+                <input
+                  type="date"
+                  className="border p-2 rounded"
+                  value={selectedDate}
+                  onChange={(e) => setSelectedDate(e.target.value)}
+                />
+              </div>
+            </div>
+          ) : (
+            <div>티커 정보를 찾을 수 없습니다.</div>
+          )}
+        </div>
+      )}
+
+      {/* 특정 날짜 티커 데이터 */}
+      {selectedSymbol && selectedDate && (
+        <div>
+          <h2 className="text-xl font-semibold mb-2">날짜별 티커 정보</h2>
+          {isLoadingDateData ? (
+            <div>날짜 데이터 로딩 중...</div>
+          ) : dateTickerData ? (
+            <div className="border p-4 rounded">
+              <h3 className="font-bold">
+                {dateTickerData.symbol} - {selectedDate}
+              </h3>
+              <p className="font-semibold mt-2">
+                가격: ${dateTickerData.price.toFixed(2)}
+              </p>
+              {/* 추가 데이터 표시 */}
+            </div>
+          ) : (
+            <div>해당 날짜의 티커 정보를 찾을 수 없습니다.</div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
+
+export default Home;

--- a/next_migration/src/components/dashboard/DashboardFooter.tsx
+++ b/next_migration/src/components/dashboard/DashboardFooter.tsx
@@ -1,0 +1,40 @@
+const DashboardFooter = () => {
+  return (
+    <footer className="border-t bg-muted/50 mt-10 py-6 text-sm leading-relaxed">
+      <div className="container mx-auto max-w-5xl space-y-2">
+        <h2 className="font-semibold">투자정보 제공 서비스 관련 고지</h2>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>
+            본 서비스는 교육·정보 제공 목적으로 종목 관련 데이터를 분석하여
+            시각화하거나 지표를 설명합니다. 특정 종목의 매수·매도 권유 또는
+            투자자문을 제공하지 않습니다.
+          </li>
+          <li>
+            한국 자본시장법 및 투자자문업 등록 요건에 따라, 본 서비스는
+            투자자문업자로 등록되지 않았으며, 투자 결정은 전적으로 사용자
+            책임입니다.
+          </li>
+          <li>
+            2024~2025년 자본시장법 개정으로 온라인 유사투자자문(리딩방 등)
+            규제가 강화되었습니다(예: 2025년 7월 14일부터 시행). 본 서비스는
+            해당 규정을 준수하며, 불법적인 종목 추천·권유 행위를 일체 하지
+            않습니다.
+          </li>
+          <li>
+            보다 상세한 사항은 당사의{" "}
+            <a href="/terms" className="underline">
+              이용약관
+            </a>{" "}
+            및
+            <a href="/privacy" className="underline">
+              개인정보처리방침
+            </a>
+            을 참조해 주시기 바랍니다.
+          </li>
+        </ul>
+      </div>
+    </footer>
+  );
+};
+
+export default DashboardFooter;

--- a/next_migration/src/components/dashboard/HeroSection.tsx
+++ b/next_migration/src/components/dashboard/HeroSection.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
+import { TrendingUp, BarChart3, Search, Newspaper, Brain } from "lucide-react";
+
+const HeroSection = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    setIsVisible(true);
+  }, []);
+
+  return (
+    <section className="relative w-full py-16 md:py-24 overflow-hidden border-b">
+      {/* 그라디언트 배경 */}
+      <div className="absolute inset-0 bg-gradient-to-br from-background via-background/95 to-primary/10 z-0" />
+
+      {/* 백그라운드 그리드 패턴 */}
+      <div className="absolute inset-0 bg-[url('/grid-pattern.svg')] bg-center opacity-5" />
+
+      <div className="container relative z-10 mx-auto max-w-5xl text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: isVisible ? 1 : 0, y: isVisible ? 0 : 20 }}
+          transition={{ duration: 0.6 }}
+          className="space-y-6"
+        >
+          {/* 상단 배지 */}
+          <div className="inline-flex items-center px-3 py-1 mb-2 text-xs font-medium rounded-full bg-primary/10 text-primary">
+            <TrendingUp size={14} className="mr-1" /> AI 시장 분석
+          </div>
+
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-primary to-primary-foreground">
+            오늘의 미국 주식 시장은?
+          </h1>
+
+          <p className="max-w-2xl mx-auto text-muted-foreground text-base md:text-lg">
+            내 종목의 상황을 AI로 분석하고, 인사이트를 제공 해요
+          </p>
+
+          {/* 핵심 기능 아이콘 */}
+          <div className="flex justify-center gap-6 py-4">
+            <div className="flex flex-col items-center">
+              <div className="p-3 rounded-full bg-muted mb-2">
+                <Search className="h-5 w-5 text-primary" />
+              </div>
+              <span className="text-xs font-medium">AI 시장 분석</span>
+            </div>
+            <div className="flex flex-col items-center">
+              <div className="p-3 rounded-full bg-muted mb-2">
+                <BarChart3 className="h-5 w-5 text-primary" />
+              </div>
+              <span className="text-xs font-medium">AI 차트 분석</span>
+            </div>
+            <div className="flex flex-col items-center">
+              <div className="p-3 rounded-full bg-muted mb-2">
+                <Newspaper className="h-5 w-5 text-primary" />
+              </div>
+              <span className="text-xs font-medium">AI 뉴스 분석</span>
+            </div>
+            <div className="flex flex-col items-center">
+              <div className="p-3 rounded-full bg-muted mb-2">
+                <Brain className="h-5 w-5 text-primary" />
+              </div>
+              <span className="text-xs font-medium">AI의 종목 추천</span>
+            </div>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default HeroSection;

--- a/next_migration/src/components/news/MarketForcastCard.tsx
+++ b/next_migration/src/components/news/MarketForcastCard.tsx
@@ -1,0 +1,321 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+import { useMarketForecast } from "@/hooks/useMarketNews";
+import { format } from "date-fns";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "../ui/drawer";
+import { useState } from "react";
+import { MarketForecastResponse } from "@/types/news";
+import { CardSkeleton } from "../ui/skeletons";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+
+type Props = {
+  title?: string;
+};
+
+const MarketForCastCard = ({ title }: Props) => {
+  const { date } = useSignalSearchParams();
+
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [selectedForecast, setSelectedForecast] = useState<{
+    date: string;
+    major: MarketForecastResponse | null;
+    minor: MarketForecastResponse | null;
+  } | null>(null);
+
+  const majorForecastQuery = useMarketForecast(
+    date ?? format(new Date(), "yyyy-MM-dd"),
+    "Major"
+  );
+
+  const minorForecastQuery = useMarketForecast(
+    date ?? format(new Date(), "yyyy-MM-dd"),
+    "Minor"
+  );
+
+  const majorForecastData = majorForecastQuery.data || [];
+  const minorForecastData = minorForecastQuery.data || [];
+
+  // 차트에 사용할 데이터 구성
+  const chartData = majorForecastData.map((item, index) => {
+    const minorItem = minorForecastData[index] || {};
+
+    return {
+      date: format(new Date(item.date_yyyymmdd), "MM/dd"),
+      majorOutlook: item.up_percentage ?? 0,
+      minorOutlook: minorItem.up_percentage ?? 0,
+      majorDirection: item.outlook,
+      minorDirection: minorItem.outlook,
+    };
+  });
+
+  const isLoading =
+    majorForecastQuery.isLoading || minorForecastQuery.isLoading;
+  const error = majorForecastQuery.error || minorForecastQuery.error;
+
+  if (isLoading) {
+    return (
+      <CardSkeleton
+        titleHeight={6}
+        cardClassName="shadow-none"
+        contentHeight={140}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 오류</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const CustomTooltip = ({
+    active,
+    payload,
+    label,
+  }: {
+    active?: boolean;
+    payload?: { value: number }[];
+    label?: string;
+  }) => {
+    if (active && payload && payload.length) {
+      const [major, minor] = payload;
+      return (
+        <div className="bg-background p-3 rounded-lg shadow-md border space-y-1">
+          <p className="text-sm font-medium">날짜: {label}</p>
+          {major && (
+            <p className="text-sm text-emerald-500">
+              전문가 예측: {Math.abs(Number(major.value))}%
+            </p>
+          )}
+          {minor && (
+            <p className="text-sm text-blue-500">
+              커뮤니티 예측: {Math.abs(Number(minor.value))}%
+            </p>
+          )}
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <Card className="shadow-none">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>{title}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4 px-0">
+        <div className="w-full h-[200px] flex justify-center items-center">
+          <ResponsiveContainer
+            width="100%"
+            height="100%"
+            className="translate-x-[8px]"
+          >
+            <LineChart
+              onClick={(event) => {
+                if (event.activePayload && event.activePayload[0]) {
+                  const clickedData = event.activePayload[0].payload;
+                  const clickedDate = clickedData.date;
+
+                  // 선택된 날짜의 원본 형식 찾기
+                  const originalDateFormat = majorForecastData.find(
+                    (item) =>
+                      format(new Date(item.date_yyyymmdd), "MM/dd") ===
+                      clickedDate
+                  )?.date_yyyymmdd;
+
+                  if (originalDateFormat) {
+                    // 해당 날짜의 Major와 Minor 예측 찾기
+                    const majorData = majorForecastData.filter(
+                      (item) =>
+                        format(new Date(item.date_yyyymmdd), "MM/dd") ===
+                        clickedDate
+                    );
+
+                    const minorData = minorForecastData.filter(
+                      (item) =>
+                        format(new Date(item.date_yyyymmdd), "MM/dd") ===
+                        clickedDate
+                    );
+
+                    // 상태 업데이트 및 Drawer 열기
+                    setSelectedForecast({
+                      date: originalDateFormat,
+                      major: majorData.length > 0 ? majorData[0] : null,
+                      minor: minorData.length > 0 ? minorData[0] : null,
+                    });
+                    setIsDrawerOpen(true);
+                  }
+                }
+              }}
+              data={chartData}
+              margin={{ top: 20, right: 30, left: 0, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" opacity={0.8} />
+              <XAxis
+                dataKey="date"
+                className="text-xs stroke-black text-black"
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Line
+                type="monotone"
+                dataKey="majorOutlook"
+                name="전문가 예측"
+                stroke="#10b981"
+                activeDot={{ r: 5 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="minorOutlook"
+                name="커뮤니티 예측"
+                stroke="#3b82f6"
+                activeDot={{ r: 5 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+
+      <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
+        <DrawerContent
+          className="w-fit mx-auto pb-10 !select-text h-full max-h-[80vh] max-sm:w-[calc(100%-14px)] max-sm:max-h-[70vh]"
+          data-vaul-drawer-direction={"bottom"}
+        >
+          <div className="mx-auto w-full max-w-4xl h-full overflow-y-scroll px-6 max-sm:px-1">
+            <DrawerHeader>
+              <DrawerClose asChild>
+                <button className="text-3xl text-white absolute -right-0 -top-10 cursor-pointer">
+                  &times;
+                </button>
+              </DrawerClose>
+              <DrawerTitle>시장 예측 세부정보</DrawerTitle>
+              <DrawerDescription>
+                {selectedForecast?.date
+                  ? format(new Date(selectedForecast.date), "yyyy-MM-dd")
+                  : date}{" "}
+                날짜 예측
+              </DrawerDescription>
+            </DrawerHeader>
+            <div className="p-4 pb-0 z-10">
+              {selectedForecast && (
+                <div className="space-y-6">
+                  {/* 전문가 시장 예측 섹션 */}
+                  <div>
+                    <h3 className="text-lg font-medium mb-2 text-emerald-500">
+                      전문가 시장 예측
+                    </h3>
+                    <div className="space-y-4">
+                      <div className="rounded-lg bg-muted/50 p-4">
+                        <h4 className="mb-2 font-medium flex items-center gap-2">
+                          <span
+                            className={cn(
+                              "inline-block w-3 h-3 rounded-full",
+                              selectedForecast.major?.outlook === "UP"
+                                ? "bg-green-500"
+                                : "bg-red-500"
+                            )}
+                          ></span>
+                          예측:{" "}
+                          {selectedForecast.major?.outlook === "UP"
+                            ? "상승"
+                            : "하락"}
+                          <span className="text-sm text-muted-foreground">
+                            ({selectedForecast.major?.up_percentage}%)
+                          </span>
+                        </h4>
+                        <p className="text-sm text-muted-foreground mb-4">
+                          날짜:{" "}
+                          {format(
+                            new Date(
+                              selectedForecast.major?.date_yyyymmdd ?? ""
+                            ),
+                            "yyyy-MM-dd"
+                          )}
+                        </p>
+                        <h4>근거</h4>
+                        <p className="text-sm text-muted-foreground whitespace-pre-line mb-4">
+                          {selectedForecast.major?.reason ||
+                            "특별한 이유가 제공되지 않았습니다."}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* 커뮤니티 시장 예측 섹션 */}
+                  <div>
+                    <h3 className="text-lg font-medium mb-2 text-blue-500">
+                      커뮤니티 시장 예측
+                    </h3>
+                    <div className="space-y-4">
+                      <div className="rounded-lg bg-muted/50 p-4">
+                        <h4 className="mb-2 font-medium flex items-center gap-2">
+                          <span
+                            className={cn(
+                              "inline-block w-3 h-3 rounded-full",
+                              selectedForecast.minor?.outlook === "UP"
+                                ? "bg-green-500"
+                                : "bg-red-500"
+                            )}
+                          ></span>
+                          예측:{" "}
+                          {selectedForecast.minor?.outlook === "UP"
+                            ? "상승"
+                            : "하락"}
+                          <span className="text-sm text-muted-foreground">
+                            ({selectedForecast.minor?.up_percentage}%)
+                          </span>
+                        </h4>
+                        <p className="text-sm text-muted-foreground mb-4">
+                          날짜:{" "}
+                          {format(
+                            new Date(
+                              selectedForecast.minor?.date_yyyymmdd ?? ""
+                            ),
+                            "yyyy-MM-dd"
+                          )}
+                        </p>
+                        <h4>근거</h4>
+                        <p className="text-sm text-muted-foreground whitespace-pre-line mb-4">
+                          {selectedForecast.minor?.reason ||
+                            "특별한 이유가 제공되지 않았습니다."}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </Card>
+  );
+};
+
+export default MarketForCastCard;

--- a/next_migration/src/components/news/MarketNewsCarousel.tsx
+++ b/next_migration/src/components/news/MarketNewsCarousel.tsx
@@ -1,0 +1,150 @@
+import { useRef, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { MarketNewsItem } from "@/types/news";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Badge } from "../ui/badge";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+
+interface MarketNewsCarouselProps {
+  items: MarketNewsItem[];
+}
+
+export function MarketNewsCarousel({ items }: MarketNewsCarouselProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [selectedItem, setSelectedItem] = useState<MarketNewsItem | null>(null);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const scroll = (dir: "left" | "right") => {
+    const container = containerRef.current;
+    if (!container) return;
+    const scrollAmount = container.clientWidth;
+    container.scrollBy({
+      left: dir === "left" ? -(scrollAmount / 2) : scrollAmount / 2,
+      behavior: "smooth",
+    });
+  };
+
+  const handleItemClick = (item: MarketNewsItem) => {
+    setSelectedItem(item);
+    setIsDrawerOpen(true);
+  };
+
+  return (
+    <div className="relative">
+      <div
+        ref={containerRef}
+        className="flex overflow-x-auto space-x-4 snap-x h-full"
+      >
+        {items?.map((item) => (
+          <div
+            key={item.id}
+            className={cn(
+              "min-w-[250px] snap-start bg-card rounded-md p-4 border justify-between flex flex-col cursor-pointer hover:shadow-md transition-shadow"
+            )}
+            onClick={() => handleItemClick(item)}
+          >
+            <div>
+              <Badge
+                className={cn(
+                  item.recommendation === "Buy" && "bg-green-500 text-white",
+                  item.recommendation === "Sell" && "bg-red-500 text-white",
+                  item.recommendation === "Hold" && "bg-yellow-500 text-white",
+                  "mb-2"
+                )}
+              >
+                {item.recommendation}
+              </Badge>
+              <p className="text-sm font-semibold mb-1">{item.headline}</p>
+              <p className="text-xs text-muted-foreground line-clamp-3">
+                {item.summary}
+              </p>
+            </div>
+            <p className="text-xs mt-2 text-muted-foreground">
+              {new Date(item.created_at).toLocaleDateString()}
+            </p>
+          </div>
+        ))}
+      </div>
+      <Button
+        variant="outline"
+        size="icon"
+        className="absolute -left-6 top-1/2 -translate-y-1/2 max-sm:hidden hidden"
+        onClick={() => scroll("left")}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="outline"
+        size="icon"
+        className="absolute -right-6 top-1/2 -translate-y-1/2 max-sm:hidden hidden"
+        onClick={() => scroll("right")}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+
+      {/* News Detail Drawer */}
+      <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
+        <DrawerContent
+          className="w-fit mx-auto pb-10 !select-text h-full max-h-[80vh] max-sm:w-[calc(100%-14px)] max-sm:max-h-[70vh]"
+          data-vaul-drawer-direction={"bottom"}
+        >
+          <div className="mx-auto w-full max-w-4xl h-full overflow-y-scroll px-6 max-sm:px-1">
+            <DrawerHeader>
+              <DrawerClose asChild>
+                <button className="text-3xl text-white absolute -right-0 -top-10 cursor-pointer">
+                  &times;
+                </button>
+              </DrawerClose>
+              <DrawerTitle>
+                {selectedItem?.headline}
+                {selectedItem?.recommendation && (
+                  <Badge
+                    className={cn(
+                      "ml-2",
+                      selectedItem.recommendation === "Buy" &&
+                        "bg-green-500 text-white",
+                      selectedItem.recommendation === "Sell" &&
+                        "bg-red-500 text-white",
+                      selectedItem.recommendation === "Hold" &&
+                        "bg-yellow-500 text-white"
+                    )}
+                  >
+                    {selectedItem.recommendation}
+                  </Badge>
+                )}
+              </DrawerTitle>
+              <DrawerDescription>
+                {selectedItem?.ticker && (
+                  <span className="font-bold mr-2">
+                    Ticker: {selectedItem.ticker}
+                  </span>
+                )}
+                {new Date(selectedItem?.created_at || "").toLocaleDateString()}
+              </DrawerDescription>
+            </DrawerHeader>
+            <div className="p-4 pb-0 z-10">
+              <div className="rounded-lg bg-muted/50 p-4">
+                <h4 className="mb-2 font-medium">Summary</h4>
+                <p className="text-sm text-muted-foreground mb-4">
+                  {selectedItem?.summary}
+                </p>
+                <h4 className="mb-2 font-medium">Details</h4>
+                <p className="text-sm text-muted-foreground whitespace-pre-line">
+                  {selectedItem?.detail_description}
+                </p>
+              </div>
+            </div>
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+}

--- a/next_migration/src/components/seo/SeoHelmet.tsx
+++ b/next_migration/src/components/seo/SeoHelmet.tsx
@@ -1,0 +1,25 @@
+import { Helmet } from "react-helmet-async";
+import { siteConfig } from "../../../seo.config";
+
+export interface SeoHelmetProps {
+  title?: string;
+  description?: string;
+  image?: string;
+}
+
+export function SeoHelmet({ title, description, image }: SeoHelmetProps) {
+  const baseTitle = siteConfig.siteName;
+  const pageTitle = title ? `${title} | ${baseTitle}` : baseTitle;
+  const desc = description ?? "Signal dashboard";
+  const img = image ?? siteConfig.defaultImage;
+
+  return (
+    <Helmet>
+      <title>{pageTitle}</title>
+      <meta name="description" content={desc} />
+      <meta property="og:title" content={pageTitle} />
+      <meta property="og:description" content={desc} />
+      <meta property="og:image" content={img} />
+    </Helmet>
+  );
+}

--- a/next_migration/src/components/signal/AiModelFilterPanel.tsx
+++ b/next_migration/src/components/signal/AiModelFilterPanel.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface AiModelFilterPanelProps {
+  availableModels: string[];
+  selectedModels: string[];
+  conditions: ("OR" | "AND")[];
+  onModelsChange: (models: string[]) => void;
+  onConditionChange: (index: number, value: "OR" | "AND") => void;
+}
+
+export function AiModelFilterPanel({
+  availableModels,
+  selectedModels,
+  conditions,
+  onModelsChange,
+  onConditionChange,
+}: AiModelFilterPanelProps) {
+  const handleModelToggle = (model: string) => {
+    const currentIndex = selectedModels.indexOf(model);
+    const newSelectedModels = [...selectedModels];
+
+    if (currentIndex === -1) {
+      newSelectedModels.push(model);
+    } else {
+      newSelectedModels.splice(currentIndex, 1);
+    }
+    onModelsChange(newSelectedModels);
+  };
+
+  const handleConditionToggle = (index: number) => {
+    const current = conditions[index] ?? "OR";
+    onConditionChange(index, current === "OR" ? "AND" : "OR");
+  };
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center">
+        <div className="flex items-center gap-2">
+          {selectedModels.map((model, index) => (
+            <React.Fragment key={model}>
+              <Badge
+                variant="secondary"
+                className={cn(
+                  "flex items-center gap-1 cursor-pointer",
+                  "bg-blue-500 text-primary-foreground"
+                )}
+                onClick={() => handleModelToggle(model)}
+              >
+                {model}
+              </Badge>
+              {index + 1 < selectedModels.length && (
+                <Button
+                  variant="link"
+                  size="sm"
+                  onClick={() => handleConditionToggle(index)}
+                  className="text-xs text-muted-foreground hover:text-foreground m-0 p-0 px-2 cursor-pointer"
+                >
+                  {conditions[index] ?? "OR"}
+                </Button>
+              )}
+            </React.Fragment>
+          ))}
+          {availableModels
+            .filter((m) => !selectedModels.includes(m))
+            .map((model) => (
+              <Badge
+                key={model}
+                variant="secondary"
+                className="flex items-center gap-1 cursor-pointer bg-secondary text-secondary-foreground"
+                onClick={() => handleModelToggle(model)}
+              >
+                {model}
+              </Badge>
+            ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/next_migration/src/components/signal/AiModelSelect.tsx
+++ b/next_migration/src/components/signal/AiModelSelect.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+
+interface AiModelSelectProps {
+  options: string[];
+  value: string;
+  onChange: (models: string) => void;
+}
+
+export function AiModelSelect({
+  options,
+  value,
+  onChange,
+}: AiModelSelectProps) {
+  const [open, setOpen] = useState(false);
+
+  const toggle = (model: string) => {
+    onChange(model);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-[200px] justify-between"
+        >
+          {value}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-0">
+        <Command>
+          <CommandList>
+            <CommandEmpty>모델이 없습니다.</CommandEmpty>
+            <CommandGroup>
+              {options.map((model) => (
+                <CommandItem
+                  key={model}
+                  onSelect={() => toggle(model)}
+                  className="cursor-pointer"
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value.includes(model) ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  {model}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/next_migration/src/components/signal/DateSelector.tsx
+++ b/next_migration/src/components/signal/DateSelector.tsx
@@ -1,0 +1,30 @@
+import { parseISO, format as formatDate } from "date-fns";
+import { DatePicker } from "@/components/ui/date-picker";
+
+interface DateSelectorProps {
+  selectedDate: string;
+  onDateChange: (dateStr: string) => void;
+  popover?: boolean; // Popover 사용 여부
+}
+
+export function DateSelector({
+  selectedDate,
+  onDateChange,
+  popover = true,
+}: DateSelectorProps) {
+  const handleDateSelect = (date: Date | undefined) => {
+    if (date) {
+      onDateChange(formatDate(date, "yyyy-MM-dd"));
+    }
+  };
+
+  return (
+    <div className="flex items-center space-x-2 max-sm:w-full">
+      <DatePicker
+        date={selectedDate ? parseISO(selectedDate) : undefined}
+        onDateChange={handleDateSelect}
+        popover={popover}
+      />
+    </div>
+  );
+}

--- a/next_migration/src/components/signal/DateSelectorWrapper.tsx
+++ b/next_migration/src/components/signal/DateSelectorWrapper.tsx
@@ -1,0 +1,33 @@
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+import { DateSelector } from "./DateSelector";
+import { useEffect, useState } from "react";
+import { formatDate } from "date-fns";
+
+type Props = {
+  // 현재는 props가 없지만, 필요시 추가할 수 있습니다.
+  popover?: boolean; // Popover 사용 여부
+};
+
+const DateSelectorWrapper = ({ popover }: Props) => {
+  const { date, setParams } = useSignalSearchParams();
+  const todayString = formatDate(new Date(), "yyyy-MM-dd");
+  const submittedDate = date ?? todayString;
+  const [selectedDate, setSelectedDate] = useState<string>(submittedDate);
+
+  useEffect(() => {
+    setSelectedDate(submittedDate);
+  }, [submittedDate]);
+
+  return (
+    <DateSelector
+      popover={popover}
+      selectedDate={selectedDate}
+      onDateChange={(date) => {
+        setSelectedDate(date);
+        setParams({ date, page: "0" });
+      }}
+    />
+  );
+};
+
+export default DateSelectorWrapper;

--- a/next_migration/src/components/signal/RecommendationCard.tsx
+++ b/next_migration/src/components/signal/RecommendationCard.tsx
@@ -1,0 +1,84 @@
+import { FC } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useNewsRecommendations } from "@/hooks/useMarketNews";
+import { format } from "date-fns";
+import { Badge } from "@/components/ui/badge";
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+import { CardSkeleton } from "../ui/skeletons";
+
+const RecommendationCard: FC<{
+  title: string;
+  recommendation: "Buy" | "Hold" | "Sell";
+  badgeColor: string;
+}> = ({ title, recommendation, badgeColor }) => {
+  const { setParams, date } = useSignalSearchParams();
+  const { data, isLoading, error } = useNewsRecommendations({
+    recommendation,
+    limit: 10,
+    date: date ? date : format(new Date(), "yyyy-MM-dd"),
+  });
+
+  const onClickTicker = (ticker: string) => {
+    setParams({ signalId: `${ticker}_OPENAI` });
+  };
+
+  if (isLoading) {
+    return (
+      <CardSkeleton
+        titleHeight={6}
+        cardClassName="shadow-none h-full"
+        contentHeight={24}
+        withBadge={true}
+      />
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>{title}</span>
+            <Badge className={badgeColor}>{recommendation.toUpperCase()}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 중 오류가 발생했습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="h-full shadow-none w-fit max-md:w-full">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>{title}</span>
+          <Badge className={badgeColor}>{recommendation.toUpperCase()}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.results.length === 0 ? (
+          <p className="text-muted-foreground">
+            해당 추천 유형의 종목이 없습니다.
+          </p>
+        ) : (
+          <div className="gap-2 flex flex-wrap">
+            {data.results.map((item) => (
+              <Badge
+                key={item.ticker}
+                variant={"secondary"}
+                className="border rounded-md px-3 cursor-pointer hover:bg-green-100 transition-colors"
+                onClick={() => onClickTicker(item.ticker)}
+              >
+                <h3 className="text-xs">{item.ticker}</h3>
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default RecommendationCard;

--- a/next_migration/src/components/signal/SignalDataTable.tsx
+++ b/next_migration/src/components/signal/SignalDataTable.tsx
@@ -1,0 +1,265 @@
+import * as React from "react";
+import {
+  ColumnDef,
+  SortingState,
+  VisibilityState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"; // Shadcn UI 경로 확인
+import { Button } from "@/components/ui/button"; // Shadcn UI 경로 확인
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"; // Shadcn UI 경로 확인
+import { SignalData } from "../../types/signal";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { TableSkeleton } from "../ui/skeletons";
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+  onRowClick?: (row: TData) => void; // 행 클릭 시 콜백 함수
+  isLoading?: boolean;
+  // 페이지네이션 상태를 외부에서 주입받기 위한 props
+  pagination: {
+    pageIndex: number;
+    pageSize: number;
+  };
+  // 페이지네이션 변경 이벤트 핸들러
+  onPaginationChange?: (pageIndex: number, pageSize: number) => void;
+}
+
+export function SignalDataTable<TData extends SignalData, TValue>({
+  columns,
+  data,
+  onRowClick,
+  isLoading,
+  pagination,
+  onPaginationChange,
+}: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = React.useState<SortingState>([
+    { desc: true, id: "signal.favorite" }, // 제출일 기준 내림차순 정렬
+    { desc: true, id: "take_profit_buy" },
+  ]); // 기본 정렬 상태 설정 (제출일 기준 내림차순)
+  const [columnFilters, setColumnFilters] = React.useState<
+    { id: string; value: unknown }[]
+  >([]);
+  const [columnVisibility, setColumnVisibility] =
+    React.useState<VisibilityState>({});
+  const [rowSelection, setRowSelection] = React.useState({});
+
+  // 실제 사용할 페이지네이션 상태 (외부 또는 내부)
+  const activePagination = pagination;
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      rowSelection,
+      pagination: {
+        pageIndex: activePagination.pageIndex,
+        pageSize: activePagination.pageSize,
+      },
+    },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    globalFilterFn: (row, columnId, filterValue) => {
+      const value = row.getValue(columnId);
+      // signal.ticker와 같이 중첩된 값에 접근하기 위한 처리
+      if (columnId.includes(".")) {
+        const keys = columnId.split(".");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let nestedValue = row.original as any;
+        for (const key of keys) {
+          if (
+            nestedValue &&
+            typeof nestedValue === "object" &&
+            key in nestedValue
+          ) {
+            nestedValue = nestedValue[key];
+          } else {
+            nestedValue = undefined;
+            break;
+          }
+        }
+        return String(nestedValue)
+          .toLowerCase()
+          .includes(String(filterValue).toLowerCase());
+      }
+      return String(value)
+        .toLowerCase()
+        .includes(String(filterValue).toLowerCase());
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <TableSkeleton
+        columnCount={columns.length}
+        rowCount={pagination.pageSize}
+      />
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  데이터를 불러오는 중입니다...
+                </TableCell>
+              </TableRow>
+            ) : table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                  onClick={() => {
+                    if (onRowClick) {
+                      onRowClick(row.original as TData);
+                      table.resetRowSelection();
+                      row.toggleSelected();
+                    }
+                  }}
+                  className="cursor-pointer hover:bg-muted/50 data-[state=selected]:bg-muted"
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  표시할 데이터가 없습니다.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2">
+        <div className="flex justify-start w-full items-center gap-4 text-sm text-muted-foreground">
+          <span>
+            {table.getState().pagination.pageSize *
+              table.getState().pagination.pageIndex}{" "}
+            / {table.getFilteredRowModel().rows.length}
+          </span>
+          <div className="flex items-center py-4">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="ml-auto">
+                  {table.getState().pagination.pageSize}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {[10, 20, 30, 50].map((size) => (
+                  <DropdownMenuCheckboxItem
+                    key={size}
+                    className="capitalize"
+                    checked={table.getState().pagination.pageSize === size}
+                    onCheckedChange={() => {
+                      table.setPageSize(size);
+                      if (onPaginationChange) {
+                        onPaginationChange(0, size);
+                      }
+                    }}
+                  >
+                    {size}줄
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="cursor-pointer"
+          onClick={() =>
+            onPaginationChange &&
+            onPaginationChange(
+              table.getState().pagination.pageIndex - 1,
+              table.getState().pagination.pageSize
+            )
+          }
+          disabled={!table.getCanPreviousPage()}
+        >
+          <ChevronLeft className="h-4 w-4 transform" />
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="cursor-pointer"
+          onClick={() =>
+            onPaginationChange &&
+            onPaginationChange(
+              table.getState().pagination.pageIndex + 1,
+              table.getState().pagination.pageSize
+            )
+          }
+          disabled={!table.getCanNextPage()}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/next_migration/src/components/signal/SignalDetailSection.tsx
+++ b/next_migration/src/components/signal/SignalDetailSection.tsx
@@ -1,0 +1,57 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { SignalDetailView } from "./SignalDetailView";
+import { useEffect, useState } from "react";
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+import { DetailSkeleton } from "../ui/skeletons";
+
+interface SignalDetailSectionProps {
+  isLoading: boolean;
+  hasSignals: boolean;
+  error?: Error | null;
+}
+
+export function SignalDetailSection({
+  isLoading,
+  error,
+}: SignalDetailSectionProps) {
+  const [open, setOpen] = useState(false);
+  const { date, setParams, signalId } = useSignalSearchParams();
+
+  useEffect(() => {
+    if (signalId) {
+      setOpen(true);
+    } else {
+      setOpen(false);
+    }
+  }, [signalId, setParams]);
+
+  const onOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      setParams({ signalId: undefined, strategy_type: undefined });
+    }
+  };
+
+  if (isLoading) {
+    return <DetailSkeleton />;
+  }
+
+  return (
+    <>
+      {error && (
+        <Alert variant="destructive" className="mb-4">
+          <AlertTitle>오류 발생</AlertTitle>
+          <AlertDescription>
+            데이터를 불러오는 중 오류가 발생했습니다: {error.message}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <SignalDetailView
+        open={open}
+        date={date ?? undefined}
+        onOpenChange={onOpenChange}
+      />
+    </>
+  );
+}

--- a/next_migration/src/components/signal/SignalDetailView.tsx
+++ b/next_migration/src/components/signal/SignalDetailView.tsx
@@ -1,0 +1,487 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { format } from "date-fns";
+import { useMarketNewsSummary } from "@/hooks/useMarketNews";
+import { MarketNewsCarousel } from "../news/MarketNewsCarousel";
+import { cn } from "@/lib/utils";
+import {
+  useSignalDataByNameAndDate,
+  useWeeklyActionCount,
+} from "@/hooks/useSignal";
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+import { useEffect, useMemo } from "react";
+import { AiModelSelect } from "./AiModelSelect";
+import { Progress } from "../ui/progress";
+import { useWeeklyPriceMovement } from "@/hooks/useTicker";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+
+interface SignalDetailViewProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  date?: string;
+}
+
+const formatDate = (
+  dateString: string | null | undefined,
+  includeTime = false
+) => {
+  if (!dateString) return "N/A";
+  try {
+    const options: Intl.DateTimeFormatOptions = {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    };
+    if (includeTime) {
+      options.hour = "2-digit";
+      options.minute = "2-digit";
+      options.second = "2-digit";
+    }
+    return new Date(dateString).toLocaleDateString("ko-KR", options);
+  } catch (error) {
+    console.error("Invalid date format:", dateString, error);
+    return dateString;
+  }
+};
+
+const formatCurrency = (amount: number | undefined | null) => {
+  if (amount == null) return "N/A"; // undefined와 null 모두 체크
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD", // 필요시 변경
+  }).format(amount);
+};
+
+export const SignalDetailView: React.FC<SignalDetailViewProps> = ({
+  open,
+  onOpenChange,
+  date,
+}) => {
+  const { signalId, setParams, strategy_type } = useSignalSearchParams();
+
+  const [symbol, aiModel] = signalId?.split("_") ?? [];
+
+  const signals = useSignalDataByNameAndDate(
+    [symbol],
+    date ?? new Date().toISOString().split("T")[0],
+    strategy_type
+  );
+
+  const data = useMemo(() => {
+    return signals.data?.signals.find(
+      (value) =>
+        value.signal.ai_model === aiModel && value.signal.ticker === symbol
+    );
+  }, [aiModel, signals.data?.signals, symbol]);
+
+  useEffect(() => {
+    if (signals.isError) {
+      setParams({
+        signalId: undefined,
+      });
+    }
+  }, [data?.signal.ticker, setParams, signals.data?.signals, signals.isError]);
+
+  const { data: marketNews } = useMarketNewsSummary({
+    news_type: "ticker",
+    ticker: data?.signal.ticker,
+    news_date: date,
+  });
+
+  const priceMovement = useWeeklyPriceMovement(
+    { direction: "up", reference_date: date, tickers: data?.signal.ticker },
+    {
+      enabled: !!data?.signal.ticker && !!date,
+    }
+  );
+
+  const weeklySignalData = useWeeklyActionCount(
+    {
+      action: "Buy",
+      tickers: data?.signal.ticker,
+      reference_date: date,
+    },
+    {
+      enabled: !!data?.signal.ticker && !!date,
+    }
+  );
+
+  if (!data) {
+    return null;
+  }
+
+  const confidenceLevel = data.signal.chart_pattern?.confidence_level
+    ? data.signal.chart_pattern?.confidence_level > 1
+      ? data.signal.chart_pattern.confidence_level * 0.01
+      : data.signal.chart_pattern?.confidence_level
+    : 0;
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="w-full max-w-4xl mx-auto pb-10 !select-text sm:max-h-[80vh] max-sm:w-[calc(100%-14px)] max-sm:max-h-[70vh]">
+        <div className="mx-auto w-full max-w-4xl h-full overflow-y-scroll px-8 max-sm:px-1">
+          <DrawerHeader className="px-0">
+            <DrawerClose asChild>
+              <button className="text-3xl text-white absolute -right-0 -top-10 cursor-pointer">
+                &times;
+              </button>
+            </DrawerClose>
+            {marketNews?.result && (
+              <div className="px-0 pb-4">
+                <MarketNewsCarousel items={marketNews?.result} />
+              </div>
+            )}
+            <div className="flex justify-between items-center">
+              <div>
+                <DrawerTitle className="text-2xl p-0 m-0 text-left">
+                  {data.signal.ticker}
+                </DrawerTitle>
+                <span className="text-muted-foreground text-sm font-light">
+                  {data.signal.timestamp &&
+                    format(data.signal.timestamp, "yyyy년 MM월 dd일")}
+                </span>
+              </div>
+              {data.signal.action && (
+                <Badge
+                  className={cn(
+                    "text-xs px-3 py-1",
+                    data.signal.action.toLowerCase() === "buy"
+                      ? "bg-green-600 text-white"
+                      : data.signal.action.toLowerCase() === "sell"
+                      ? "bg-red-500 text-white"
+                      : "bg-yellow-500 text-white"
+                  )}
+                >
+                  {data.signal.action.toUpperCase()}
+                </Badge>
+              )}
+            </div>
+          </DrawerHeader>
+
+          <div className="">
+            <section className="flex gap-2 flex-col mb-4">
+              <div className="flex flex-col">
+                <strong>7일간 주식 움직임</strong>
+                <div className="flex flex-wrap gap-1">
+                  {priceMovement.data?.tickers[0]?.count.map((count, index) => (
+                    <Tooltip>
+                      <TooltipTrigger className="cursor-pointer">
+                        <Badge
+                          key={count}
+                          className={cn(
+                            "text-xs bg-blue-500 text-white justify-center in-checked:",
+                            count > 0 ? "bg-green-600" : "bg-red-400"
+                          )}
+                        >
+                          {count > 0 ? "상승" : "하락"}
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {priceMovement.data?.tickers?.[0]?.date[index] ?? "N/A"}
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex flex-col">
+                {weeklySignalData.data?.signals[0].count?.length && (
+                  <strong>7일간 상승 시그널</strong>
+                )}
+                <div className="flex flex-wrap gap-1">
+                  {weeklySignalData.data?.signals[0].count.map(
+                    (count, index) => (
+                      <Tooltip>
+                        <TooltipTrigger className="cursor-pointer">
+                          <Badge
+                            key={count}
+                            className={cn(
+                              "text-xs bg-blue-500 text-white justify-center in-checked:",
+                              count > 0 ? "bg-green-600" : "bg-red-400"
+                            )}
+                          >
+                            {count}개
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {priceMovement.data?.tickers?.[0]?.date[index] ??
+                            "N/A"}
+                        </TooltipContent>
+                      </Tooltip>
+                    )
+                  )}
+                </div>
+              </div>
+            </section>
+            {/* 시그널 정보 */}
+            <section>
+              <h3 className="text-lg font-semibold mb-2 border-b pb-1">
+                예측 정보
+              </h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="w-full flex flex-col">
+                  <strong>전략:</strong>{" "}
+                  <div className="flex flex-wrap gap-1">
+                    {data.signal.strategy
+                      ?.split(",")
+                      .map((strategy) => (
+                        <Badge key={strategy}>{strategy}</Badge>
+                      )) ?? "N/A"}
+                  </div>
+                </div>
+                <div className="flex gap-2 items-center">
+                  <strong>LLM 모델:</strong>
+                  <AiModelSelect
+                    options={[
+                      ...new Set(
+                        signals.data?.signals.map(
+                          (signal) => signal.signal.ai_model ?? ""
+                        )
+                      ),
+                    ]}
+                    value={aiModel}
+                    onChange={(value) => {
+                      const newSignalId = `${data.signal.ticker}_${value}`;
+                      setParams({ signalId: newSignalId });
+                    }}
+                  />
+                </div>
+                {data.signal.probability && (
+                  <div>
+                    <strong>확률:</strong>{" "}
+                    <Badge
+                      variant={
+                        data.signal.probability.toLowerCase() === "high"
+                          ? "default"
+                          : data.signal.probability.toLowerCase() === "medium"
+                          ? "secondary"
+                          : data.signal.probability.toLowerCase() === "low"
+                          ? "destructive"
+                          : "outline"
+                      }
+                    >
+                      {data.signal.probability}
+                    </Badge>
+                  </div>
+                )}
+                <div>
+                  <strong>진입 가격:</strong>{" "}
+                  {formatCurrency(data.signal.entry_price)}
+                </div>
+                {data.signal.stop_loss && (
+                  <div>
+                    <strong>손절 가격:</strong>{" "}
+                    {formatCurrency(data.signal.stop_loss)}
+                  </div>
+                )}
+                {data.signal.take_profit && (
+                  <div>
+                    <strong>익절 가격:</strong>{" "}
+                    {formatCurrency(data.signal.take_profit)}
+                  </div>
+                )}
+                {data.signal.chart_pattern && (
+                  <div className="mt-4 w-full md:col-span-2">
+                    <h3 className="text-lg font-semibold mb-2 border-b pb-1">
+                      차트 패턴 분석
+                    </h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <strong>패턴:</strong>
+                        <Badge
+                          className={cn(
+                            "capitalize flex flex-wrap text-wrap whitespace-pre-wrap",
+                            data.signal.chart_pattern.pattern_type ===
+                              "bullish" && "bg-green-600 text-white",
+                            data.signal.chart_pattern.pattern_type ===
+                              "bearish" && "bg-red-500 text-white",
+                            data.signal.chart_pattern.pattern_type ===
+                              "neutral" && "bg-yellow-500 text-white"
+                          )}
+                        >
+                          {data.signal.chart_pattern.name}
+                        </Badge>
+                      </div>
+                      <div>
+                        <strong>패턴 유형:</strong>{" "}
+                        <Badge
+                          className={cn(
+                            "capitalize",
+                            data.signal.chart_pattern.pattern_type ===
+                              "bullish" && "bg-green-600 text-white",
+                            data.signal.chart_pattern.pattern_type ===
+                              "bearish" && "bg-red-500 text-white",
+                            data.signal.chart_pattern.pattern_type ===
+                              "neutral" && "bg-yellow-500 text-white"
+                          )}
+                        >
+                          {data.signal.chart_pattern.pattern_type === "bullish"
+                            ? "상승"
+                            : data.signal.chart_pattern.pattern_type ===
+                              "bearish"
+                            ? "하락"
+                            : "중립"}
+                        </Badge>
+                      </div>
+                      <div>
+                        <strong className="flex items-center">
+                          신뢰도:
+                          <span className="text-sm ml-2">
+                            {confidenceLevel * 100}%
+                          </span>
+                        </strong>{" "}
+                        <Progress value={confidenceLevel * 100} />
+                      </div>
+                      <div className="md:col-span-2">
+                        <strong>차트 설명:</strong>{" "}
+                        <p className="text-sm text-muted-foreground">
+                          {data.signal.chart_pattern.description}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+                {data.signal.senario && (
+                  <div className="md:col-span-2">
+                    <strong>시나리오:</strong> {data.signal.senario}
+                  </div>
+                )}
+                {data.signal.good_things && (
+                  <div className="md:col-span-2">
+                    <strong>긍정적 요인:</strong> {data.signal.good_things}
+                  </div>
+                )}
+                {data.signal.bad_things && (
+                  <div className="md:col-span-2">
+                    <strong>부정적 요인:</strong> {data.signal.bad_things}
+                  </div>
+                )}
+              </div>
+              {data.signal.report_summary && (
+                <div className="mt-2">
+                  <strong>리포트 요약:</strong>{" "}
+                  <p className="text-sm text-muted-foreground">
+                    {data.signal.report_summary}
+                  </p>
+                </div>
+              )}
+              {data.signal.result_description && (
+                <div className="mt-2">
+                  <strong>결과 설명:</strong>{" "}
+                  <p className="text-sm text-muted-foreground">
+                    {data.signal.result_description}
+                  </p>
+                </div>
+              )}
+            </section>
+
+            {/* 티커 정보 */}
+            {data.ticker?.name && (
+              <section>
+                <div className="flex flex-col border-b pb-1 mb-2">
+                  <h3 className="text-lg font-semibold">{data.ticker.name}</h3>
+                  <span className="text-sm text-muted-foreground font-light">
+                    Close Price [{formatDate(data.ticker.ticker_date)}]
+                  </span>
+                </div>
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>항목</TableHead>
+                        <TableHead>가격</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      <TableRow>
+                        <TableCell>현재가</TableCell>
+                        <TableCell>
+                          {formatCurrency(data.ticker.price)}
+                        </TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell>시가</TableCell>
+                        <TableCell>
+                          {formatCurrency(data.ticker.open_price)}
+                        </TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell>고가</TableCell>
+                        <TableCell>
+                          {formatCurrency(data.ticker.high_price)}
+                        </TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell>저가</TableCell>
+                        <TableCell>
+                          {formatCurrency(data.ticker.low_price)}
+                        </TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell>종가</TableCell>
+                        <TableCell>
+                          {formatCurrency(data.ticker.close_price)}
+                        </TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell>거래량</TableCell>
+                        <TableCell>
+                          {data.ticker.volume?.toLocaleString()}
+                        </TableCell>
+                      </TableRow>
+                    </TableBody>
+                  </Table>
+                </div>
+              </section>
+            )}
+
+            {/* 결과 정보 */}
+            {data.result && (
+              <section>
+                <h3 className="text-lg font-semibold mb-2 border-b pb-1">
+                  실제 결과
+                </h3>
+                <div className="flex flex-wrap items-center gap-4">
+                  <div>
+                    <Badge>{data.result.action.toUpperCase()}</Badge>
+                  </div>
+                  <div>
+                    {data.result.is_correct ? (
+                      <Badge className="bg-green-600 hover:bg-green-600 text-white">
+                        성공
+                      </Badge>
+                    ) : (
+                      <Badge variant="destructive">실패</Badge>
+                    )}
+                  </div>
+                  <div>
+                    <strong>가격 변화:</strong>{" "}
+                    {data.ticker?.close_price &&
+                      data.ticker?.open_price &&
+                      formatCurrency(
+                        data.ticker.close_price - data.ticker.open_price
+                      )}
+                  </div>
+                </div>
+              </section>
+            )}
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/next_migration/src/components/signal/SignalListWrapper.tsx
+++ b/next_migration/src/components/signal/SignalListWrapper.tsx
@@ -1,0 +1,43 @@
+import { ColumnDef } from "@tanstack/react-table";
+import { SignalData } from "@/types/signal";
+import { SignalDataTable } from "./SignalDataTable";
+import { PropsWithChildren } from "react";
+
+interface SignalListWrapperProps {
+  submittedDate: string;
+  columns: ColumnDef<SignalData, unknown>[];
+  data: SignalData[];
+  onRowClick: (signal: SignalData) => void;
+  isLoading?: boolean;
+  // 페이지네이션 상태 추가
+  pagination: {
+    pageIndex: number;
+    pageSize: number;
+  };
+  // 페이지네이션 변경 이벤트 핸들러 추가
+  onPaginationChange?: (pageIndex: number, pageSize: number) => void;
+}
+
+export function SignalListWrapper({
+  columns,
+  data,
+  onRowClick,
+  isLoading,
+  children,
+  pagination,
+  onPaginationChange,
+}: PropsWithChildren<SignalListWrapperProps>) {
+  return (
+    <div className="mb-8">
+      {children}
+      <SignalDataTable
+        columns={columns}
+        data={data}
+        onRowClick={onRowClick}
+        isLoading={isLoading}
+        pagination={pagination}
+        onPaginationChange={onPaginationChange}
+      />
+    </div>
+  );
+}

--- a/next_migration/src/components/signal/SignalSearchInput.tsx
+++ b/next_migration/src/components/signal/SignalSearchInput.tsx
@@ -1,0 +1,120 @@
+import { useState, useMemo } from "react"; // useMemo 추가
+import { Search, Check } from "lucide-react"; // Check 아이콘 추가
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils"; // cn 유틸리티 추가
+import { Button } from "../ui/button";
+
+type Props = {
+  selectedTickers: string[]; // 선택된 티커 배열
+  onSelectedTickersChange: (tickers: string[]) => void; // 티커 변경 시 호출될 함수
+  availableTickers?: string[]; // 드롭다운에 표시될 전체 티커 목록
+  placeholder?: string;
+};
+
+const SignalSearchInput = ({
+  selectedTickers,
+  onSelectedTickersChange,
+  availableTickers = [],
+  placeholder = "티커 검색 (다중 선택)",
+}: Props) => {
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState(""); // 입력 필드의 현재 값 (필터링용)
+
+  const filteredDropdownTickers = useMemo(() => {
+    if (!inputValue) {
+      // 입력값이 없으면 모든 사용 가능한 티커를 보여줌
+      return availableTickers;
+    }
+    return availableTickers.filter((ticker) =>
+      ticker.toLowerCase().includes(inputValue.toLowerCase())
+    );
+  }, [inputValue, availableTickers]);
+
+  const handleToggleTicker = (tickerToToggle: string) => {
+    const newSelectedTickers = selectedTickers.includes(tickerToToggle)
+      ? selectedTickers.filter((t) => t !== tickerToToggle) // 이미 선택된 경우 제거
+      : [...selectedTickers, tickerToToggle]; // 선택되지 않은 경우 추가
+    onSelectedTickersChange(newSelectedTickers);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild className="">
+        <div className="relative w-fit max-sm:w-full">
+          <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Button
+            variant={"outline"}
+            className="pl-7 w-[250px] flex justify-start cursor-pointer max-sm:w-full"
+          >
+            {placeholder}
+          </Button>
+        </div>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[--radix-popover-trigger-width] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput
+            placeholder={placeholder}
+            value={inputValue}
+            onValueChange={(value) => {
+              setInputValue(value);
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            className="border-b"
+          />
+          <CommandList>
+            <CommandEmpty className="px-2 py-2">
+              {inputValue && filteredDropdownTickers.length === 0
+                ? "해당 티커가 없습니다."
+                : availableTickers.length === 0
+                ? "선택 가능한 티커가 없습니다."
+                : "티커를 검색하거나 선택하세요."}
+            </CommandEmpty>
+            {filteredDropdownTickers.length > 0 && (
+              <CommandGroup>
+                {filteredDropdownTickers.map((ticker) => (
+                  <CommandItem
+                    key={ticker}
+                    value={ticker}
+                    onSelect={() => {
+                      handleToggleTicker(ticker);
+                    }}
+                    className="cursor-pointer"
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        selectedTickers.includes(ticker)
+                          ? "opacity-100" // 선택된 경우 체크 표시
+                          : "opacity-0"
+                      )}
+                    />
+                    {ticker}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default SignalSearchInput;

--- a/next_migration/src/components/signal/SummaryTabsCard.tsx
+++ b/next_migration/src/components/signal/SummaryTabsCard.tsx
@@ -1,0 +1,43 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+type Props = {
+  tabs: {
+    value: string;
+    label: string;
+    component: React.ReactNode;
+  }[];
+};
+
+const SummaryTabsCard = ({ tabs }: Props) => {
+  const defaultValue = tabs.length > 0 ? tabs[0].value : "";
+
+  return (
+    <Tabs defaultValue={defaultValue} className="w-full h-full">
+      <Card className="shadow-none gap-2 h-full">
+        <CardHeader className="px-6 py-0">
+          <TabsList className="w-fit max-w-[450px] flex items-center justify-center text-wrap whitespace-pre-wrap">
+            {tabs.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </CardHeader>
+        <CardContent className="w-full py-0 h-full">
+          {tabs.map((tab) => (
+            <TabsContent
+              key={tab.value}
+              value={tab.value}
+              className="outline-none h-full"
+            >
+              <div className="flex-1 h-full">{tab.component}</div>
+            </TabsContent>
+          ))}
+        </CardContent>
+      </Card>
+    </Tabs>
+  );
+};
+
+export default SummaryTabsCard;

--- a/next_migration/src/components/signal/WeeklyActionCountCard.tsx
+++ b/next_migration/src/components/signal/WeeklyActionCountCard.tsx
@@ -1,0 +1,100 @@
+import { FC } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useWeeklyActionCount } from "@/hooks/useSignal";
+import { GetWeeklyActionCountParams } from "@/types/signal";
+import { Badge } from "../ui/badge";
+import { cn } from "@/lib/utils";
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+import { CardSkeleton } from "../ui/skeletons";
+
+interface WeeklyActionCountCardProps {
+  title: string;
+  params: GetWeeklyActionCountParams;
+}
+
+export const WeeklyActionCountCard: FC<WeeklyActionCountCardProps> = ({
+  title,
+  params,
+}) => {
+  const { setParams } = useSignalSearchParams();
+
+  const { data, isLoading, error } = useWeeklyActionCount(params, {
+    select(data) {
+      return {
+        signals: data.signals
+          .sort((a, b) => {
+            if (a.count && b.count) {
+              const aCount = a.count.reduce((sum, val) => sum + (val || 0), 0);
+              const bCount = b.count.reduce((sum, val) => sum + (val || 0), 0);
+              return bCount - aCount;
+            }
+            return 0;
+          })
+          .slice(0, 10),
+      };
+    },
+  });
+
+  const onClickTicker = (ticker: string) => {
+    setParams({ signalId: `${ticker}_OPENAI` });
+  };
+
+  if (isLoading) {
+    return (
+      <CardSkeleton
+        titleHeight={6}
+        cardClassName="shadow-none"
+        contentHeight={24}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 오류</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="shadow-none">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between font-medium">
+          <span>{title}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data?.signals && data.signals.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {data.signals.map(({ ticker, count }) => (
+              <Badge
+                key={ticker}
+                variant="secondary"
+                className="flex gap-2 hover:bg-green-100 cursor-pointer transition-colors"
+                onClick={() => onClickTicker(ticker)}
+              >
+                <span>{ticker}</span>
+                <span
+                  className={cn(
+                    "font-bold",
+                    params.action === "Buy" ? "text-green-600" : "text-red-600"
+                  )}
+                >
+                  {count.reduce((sum, val) => sum + (val || 0), 0)}
+                </span>
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground">데이터가 없습니다.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/next_migration/src/components/signal/WeeklyPriceMovementCard.tsx
+++ b/next_migration/src/components/signal/WeeklyPriceMovementCard.tsx
@@ -1,0 +1,99 @@
+import { FC } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useWeeklyPriceMovement } from "@/hooks/useTicker";
+import { GetWeeklyPriceMovementParams } from "@/types/ticker";
+import { Badge } from "../ui/badge";
+import { cn } from "@/lib/utils";
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+import { CardSkeleton } from "../ui/skeletons";
+
+interface WeeklyPriceMovementCardProps {
+  title: string;
+  params: GetWeeklyPriceMovementParams;
+}
+
+export const WeeklyPriceMovementCard: FC<WeeklyPriceMovementCardProps> = ({
+  title,
+  params,
+}) => {
+  const { setParams } = useSignalSearchParams();
+
+  const { data, isLoading, error } = useWeeklyPriceMovement(params, {
+    select(data) {
+      return {
+        tickers: data.tickers
+          .sort((a, b) => {
+            const aSum = a.count.reduce((sum, val) => sum + (val || 0), 0);
+            const bSum = b.count.reduce((sum, val) => sum + (val || 0), 0);
+            return bSum - aSum;
+          })
+          .slice(0, 10),
+      };
+    },
+  });
+
+  const onClickTicker = (ticker: string) => {
+    setParams({ signalId: `${ticker}_OPENAI` });
+  };
+
+  if (isLoading) {
+    return (
+      <CardSkeleton
+        titleHeight={6}
+        cardClassName="shadow-none"
+        contentHeight={24}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 오류</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="shadow-none">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between font-medium">
+          <span>{title}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data?.tickers && data.tickers.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {data.tickers.map(({ ticker, count }) => (
+              <Badge
+                key={ticker}
+                variant="secondary"
+                className="flex gap-2 hover:bg-green-100 cursor-pointer transition-colors"
+                onClick={() => onClickTicker(ticker)}
+              >
+                <span>{ticker}</span>
+                <span
+                  className={cn(
+                    "font-bold",
+                    params.direction === "up"
+                      ? "text-green-600"
+                      : "text-red-600"
+                  )}
+                >
+                  {count.reduce((sum, val) => sum + (val || 0), 0)}
+                </span>
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground">데이터가 없습니다.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/next_migration/src/components/signal/columns.tsx
+++ b/next_migration/src/components/signal/columns.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { SignalData } from "../../types/signal";
+import { ArrowUpDown, Star } from "lucide-react";
+import { Button } from "@/components/ui/button"; // Shadcn UI의 Button 임포트 경로 확인 필요
+import { Badge } from "@/components/ui/badge"; // Shadcn UI의 Badge 임포트 경로 확인 필요
+import { cn } from "@/lib/utils";
+
+// Helper function to format date string
+const formatCurrency = (amount: number | undefined | null) => {
+  if (!amount) return "N/A"; // undefined와 null 모두 체크
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD", // 통화는 실제 데이터에 맞게 조정
+  }).format(amount);
+};
+
+export const createColumns = (
+  favorites: string[],
+  toggleFavorite: (ticker: string) => void
+): ColumnDef<SignalData>[] => [
+  {
+    id: "signal.favorite",
+    accessorKey: "signal.favorite",
+    header: "",
+    cell: ({ row }) => {
+      const ticker = row.original.signal.ticker;
+      const isFav = favorites.includes(ticker);
+      return (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleFavorite(ticker);
+          }}
+          className="cursor-pointer flex justify-center items-center"
+        >
+          <Star
+            className="h-4 w-4"
+            fill={isFav ? "#facc15" : "none"}
+            stroke={isFav ? "#facc15" : "currentColor"}
+          />
+        </button>
+      );
+    },
+  },
+  {
+    accessorKey: "signal.ticker",
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Ticker
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      // Generate image URL dynamically
+      const ticker = row.original.signal.ticker.toUpperCase();
+      const imageUrl = `/logos/${ticker}.png`;
+      // You could add error handling with onError in the img tag
+
+      return (
+        <div className="font-medium items-center justify-start flex">
+          {imageUrl && (
+            <img src={imageUrl} alt="Stock Icon" className="h-6 w-6 mr-1" />
+          )}
+          {row.original.signal.ticker}
+        </div> // 기본 왼쪽 정렬
+      );
+    },
+  },
+  {
+    accessorKey: "signal.action",
+    header: ({ column }) => {
+      // 정렬 기능 추가
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          액션
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      const action = row.original.signal.action;
+      if (!action) return <Badge variant="outline">N/A</Badge>; // Badge는 기본적으로 내용에 따라 정렬
+      return (
+        <Badge
+          className={cn(
+            "w-fit",
+            action.toLowerCase() === "buy" && "bg-green-500 text-white",
+            action.toLowerCase() === "sell" && "bg-red-500 text-white",
+            action.toLowerCase() === "hold" && "bg-yellow-500 text-white"
+          )}
+        >
+          {action.toUpperCase()}
+        </Badge>
+      );
+    },
+  },
+
+  {
+    accessorKey: "signal.entry_price",
+    header: "진입 가격",
+    cell: ({ row }) => {
+      return (
+        <div className="font-medium">
+          {formatCurrency(row.original.signal.entry_price)}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: "signal.close_price",
+    header: "종료 가격",
+    cell: ({ row }) => {
+      return (
+        <div className="font-medium">
+          {formatCurrency(row.original.signal.close_price)}
+        </div>
+      );
+    },
+  },
+  {
+    id: "take_profit_buy",
+    accessorFn: (row) => {
+      const { entry_price, take_profit } = row.signal;
+      if (entry_price && take_profit && entry_price !== 0) {
+        return ((take_profit - entry_price) / entry_price) * 100;
+      }
+      return null;
+    },
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          익절가격 (%)
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      const { signal } = row.original;
+      const { entry_price, take_profit } = signal;
+      let percentageString = "";
+      if (entry_price && take_profit && entry_price !== 0) {
+        const percentage = ((take_profit - entry_price) / entry_price) * 100;
+        percentageString = ` (${percentage >= 0 ? "+" : ""}${percentage.toFixed(
+          2
+        )}%)`;
+      }
+      return (
+        <div className="font-medium">
+          {formatCurrency(take_profit)}
+          {percentageString && (
+            <span
+              className={
+                parseFloat(percentageString.replace(/[()%+]/g, "")) >= 0
+                  ? "text-green-600"
+                  : "text-red-600"
+              }
+            >
+              {percentageString}
+            </span>
+          )}
+        </div>
+      );
+    },
+  },
+  {
+    id: "stop_loss_sell",
+    accessorFn: (row) => {
+      const { entry_price, stop_loss } = row.signal;
+      if (entry_price && stop_loss && entry_price !== 0) {
+        return ((stop_loss - entry_price) / entry_price) * 100;
+      }
+      return null;
+    },
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          손절가격 (%)
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      const { signal } = row.original;
+      const { entry_price, stop_loss } = signal;
+      let percentageString = "";
+      if (entry_price && stop_loss && entry_price !== 0) {
+        const percentage = ((stop_loss - entry_price) / entry_price) * 100;
+        percentageString = ` (${percentage >= 0 ? "+" : ""}${percentage.toFixed(
+          2
+        )}%)`;
+      }
+      return (
+        <div className="font-medium">
+          {formatCurrency(stop_loss)}
+          {percentageString && (
+            <span
+              className={
+                parseFloat(percentageString.replace(/[()%+]/g, "")) >= 0
+                  ? "text-green-600"
+                  : "text-red-600"
+              }
+            >
+              {percentageString}
+            </span>
+          )}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: "signal.probability",
+    header: ({ column }) => {
+      // 정렬 기능 추가
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          확률
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      const probability = row.original.signal.probability;
+      if (!probability) return <Badge variant="outline">N/A</Badge>; // Badge는 기본적으로 내용에 따라 정렬
+      let variant: "default" | "secondary" | "destructive" | "outline" =
+        "secondary";
+      if (probability.toLowerCase() === "high") variant = "default";
+      else if (probability.toLowerCase() === "low") variant = "destructive";
+      return <Badge variant={variant}>{probability}</Badge>;
+    },
+  },
+  {
+    accessorKey: "result.signal.ai_model",
+    header: "LLM 모델",
+    cell: ({ row }) => {
+      return (
+        <Badge
+          variant="default"
+          className="bg-green-500 hover:bg-green-600 text-white"
+        >
+          {row.original.signal?.ai_model ?? "N/A"}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: "result.is_correct",
+    header: "결과",
+    cell: ({ row }) => {
+      const isCorrect = row.original.result?.is_correct;
+      if (isCorrect == null) return <Badge variant="outline">N/A</Badge>; // Badge는 기본적으로 내용에 따라 정렬
+      return isCorrect ? (
+        <Badge
+          variant="default"
+          className="bg-green-500 hover:bg-green-600 text-white"
+        >
+          OK
+        </Badge>
+      ) : (
+        <Badge variant="destructive">NO</Badge>
+      );
+    },
+  },
+  {
+    accessorKey: "result.price_diff",
+    header: "가격차이",
+    cell: ({ row }) => {
+      const priceDiff = row.original.result?.price_diff;
+      return <div className="font-medium">{formatCurrency(priceDiff)}</div>;
+    },
+  },
+];

--- a/next_migration/src/components/withDateValidation.tsx
+++ b/next_migration/src/components/withDateValidation.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
+import { useRouter } from "next/navigation";
+
+export function withDateValidation<T extends object>(
+  Component: React.ComponentType<T>
+) {
+  return function WrappedComponent(props: T) {
+    const { date, setParams } = useSignalSearchParams();
+    const router = useRouter();
+
+    useEffect(() => {
+      const today = new Date();
+      const oneMonthAgo = new Date();
+      oneMonthAgo.setMonth(today.getMonth() - 1);
+
+      const todayFormatted = today.toISOString().split("T")[0];
+
+      const isWeekend = (date: Date) =>
+        date.getDay() === 0 || date.getDay() === 6;
+
+      const getClosestWorkingDay = (date: Date) => {
+        const closestDate = new Date(date);
+        while (isWeekend(closestDate)) {
+          closestDate.setDate(closestDate.getDate() - 1);
+        }
+        return closestDate.toISOString().split("T")[0];
+      };
+
+      const isBefore11AM = (date: Date) => date.getHours() < 11;
+
+      if (date) {
+        const currentDate = new Date(date);
+
+        // 날짜가 오늘을 초과하면 오늘로 리다이렉트
+        if (currentDate > today) {
+          setParams({ date: todayFormatted });
+          router.replace(`?date=${todayFormatted}`);
+        }
+
+        // 날짜가 한 달 전보다 이전이면 한 달 전으로 리다이렉트
+        if (currentDate < oneMonthAgo) {
+          setParams({ date: todayFormatted });
+          router.replace(`?date=${todayFormatted}`);
+        }
+
+        // 날짜가 주말이면 가장 가까운 평일로 리다이렉트
+        if (isWeekend(currentDate)) {
+          const closestWorkingDay = getClosestWorkingDay(currentDate);
+          setParams({ date: closestWorkingDay });
+          router.replace(`?date=${closestWorkingDay}`);
+        }
+      } else {
+        // 날짜가 없으면 오늘 날짜로 설정
+        let defaultDate = todayFormatted;
+
+        // 오늘이 오전 11시 이전이면 어제 또는 가장 가까운 평일로 설정
+        if (isBefore11AM(today)) {
+          const yesterday = new Date();
+          yesterday.setDate(today.getDate() - 1);
+          defaultDate = getClosestWorkingDay(yesterday);
+        }
+
+        // 오늘이 주말이면 가장 가까운 평일로 설정
+        if (isWeekend(today)) {
+          defaultDate = getClosestWorkingDay(today);
+        }
+
+        setParams({ date: defaultDate });
+        router.replace(`?date=${defaultDate}`);
+      }
+    }, [date, setParams, router]);
+
+    return <Component {...props} />;
+  };
+}

--- a/next_migration/src/hooks/useDashboardFilters.ts
+++ b/next_migration/src/hooks/useDashboardFilters.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { format as formatDate, parseISO } from "date-fns";
+
+const getParam = (
+  searchParams: URLSearchParams,
+  key: string,
+  defaultValue: string | null = null
+) => searchParams.get(key) ?? defaultValue;
+
+const getArrayParam = (searchParams: URLSearchParams, key: string) => {
+  const param = searchParams.get(key);
+  return param ? param.split(",").filter(Boolean) : [];
+};
+
+export function useDashboardFilters() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const todayString = formatDate(new Date(), "yyyy-MM-dd");
+
+  const initialDate = useMemo(() => {
+    const dateFromUrl = searchParams.get("date");
+    if (dateFromUrl && /^\d{4}-\d{2}-\d{2}$/.test(dateFromUrl)) {
+      try {
+        const parsed = parseISO(dateFromUrl);
+        if (formatDate(parsed, "yyyy-MM-dd") === dateFromUrl) {
+          return dateFromUrl;
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    return todayString;
+  }, [searchParams, todayString]);
+
+  const [selectedDate, setSelectedDate] = useState<string>(initialDate);
+  const [submittedDate, setSubmittedDate] = useState<string>(initialDate);
+  const [selectedSignalId, setSelectedSignalId] = useState<string | null>(() =>
+    getParam(searchParams, "signalId")
+  );
+  const [globalFilter, setGlobalFilter] = useState<string>(
+    () => getParam(searchParams, "q") ?? ""
+  );
+  const [selectedAiModels, setSelectedAiModels] = useState<string[]>(() =>
+    getArrayParam(searchParams, "models")
+  );
+  const [aiModelFilterConditions, setAiModelFilterConditions] = useState<
+    ("OR" | "AND")[]
+  >(() => {
+    const condParam = getParam(searchParams, "condition") ?? "";
+    return condParam
+      .split(",")
+      .filter(Boolean)
+      .map((c) => (c === "AND" ? "AND" : "OR"));
+  });
+
+  const updateUrlParams = useCallback(() => {
+    const params = new URLSearchParams();
+    if (submittedDate !== todayString) params.set("date", submittedDate);
+    if (selectedSignalId) params.set("signalId", selectedSignalId);
+    if (globalFilter) params.set("q", globalFilter);
+    if (selectedAiModels.length > 0)
+      params.set("models", selectedAiModels.join(","));
+    if (aiModelFilterConditions.length > 0)
+      params.set("condition", aiModelFilterConditions.join(","));
+
+    if (params.toString() !== searchParams.toString()) {
+      router.replace('?' + params.toString());
+    }
+  }, [
+    submittedDate,
+    selectedSignalId,
+    globalFilter,
+    selectedAiModels,
+    aiModelFilterConditions,
+    router,
+    todayString,
+    searchParams,
+  ]);
+
+  useEffect(() => {
+    updateUrlParams();
+  }, [updateUrlParams]);
+
+  return {
+    selectedDate,
+    setSelectedDate,
+    submittedDate,
+    setSubmittedDate,
+    selectedSignalId,
+    setSelectedSignalId,
+    globalFilter,
+    setGlobalFilter,
+    selectedAiModels,
+    setSelectedAiModels,
+    aiModelFilterConditions,
+    setAiModelFilterConditions,
+  };
+}

--- a/next_migration/src/hooks/useFavoriteTickers.ts
+++ b/next_migration/src/hooks/useFavoriteTickers.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "favoriteTickers";
+
+export function useFavoriteTickers() {
+  const [favorites, setFavorites] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? (JSON.parse(stored) as string[]) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+    } catch {
+      // ignore write errors
+    }
+  }, [favorites]);
+
+  const toggleFavorite = (ticker: string) => {
+    setFavorites((prev) =>
+      prev.includes(ticker)
+        ? prev.filter((t) => t !== ticker)
+        : [...prev, ticker]
+    );
+  };
+
+  return { favorites, toggleFavorite };
+}

--- a/next_migration/src/hooks/useMarketNews.ts
+++ b/next_migration/src/hooks/useMarketNews.ts
@@ -1,0 +1,64 @@
+import { useQuery } from "@tanstack/react-query";
+import { newsService } from "@/services/newsService";
+import {
+  GetMarketNewsSummaryRequestParams,
+  GetNewsRecommendationsParams,
+  MarketForecastResponse,
+  MarketNewsResponse,
+  NewsRecommendationsResponse,
+} from "@/types/news";
+
+export const MARKET_NEWS_KEYS = {
+  all: ["marketNews"] as const,
+  summary: (ticker?: string, newsDate?: string, newsType?: string) =>
+    [...MARKET_NEWS_KEYS.all, "summary", ticker, newsDate, newsType] as const,
+};
+
+export const useMarketNewsSummary = ({
+  news_type,
+  ticker,
+  news_date,
+}: GetMarketNewsSummaryRequestParams) => {
+  return useQuery<MarketNewsResponse, Error>({
+    queryKey: MARKET_NEWS_KEYS.summary(ticker, news_date, news_type),
+    queryFn: () =>
+      newsService.getMarketNewsSummary({
+        news_type,
+        ticker,
+        news_date,
+      }),
+  });
+};
+
+export const NEWS_RECOMMENDATION_KEYS = {
+  all: ["newsRecommendations"] as const,
+  by: (recommendation: string, limit: number, date?: string) =>
+    [...NEWS_RECOMMENDATION_KEYS.all, recommendation, limit, date] as const,
+};
+
+export const useNewsRecommendations = ({
+  recommendation,
+  limit = 5,
+  date,
+}: GetNewsRecommendationsParams) => {
+  return useQuery<NewsRecommendationsResponse, Error>({
+    queryKey: NEWS_RECOMMENDATION_KEYS.by(recommendation, limit, date),
+    queryFn: () =>
+      newsService.getNewsRecommendations({
+        recommendation,
+        limit,
+        date,
+      }),
+  });
+};
+
+export const useMarketForecast = (
+  date: string,
+  source: MarketForecastResponse["source"]
+) => {
+  return useQuery<MarketForecastResponse[], Error>({
+    queryKey: ["marketForecast", date, source],
+    queryFn: () => newsService.getMarketForecast({ date, source }),
+    enabled: !!date, // 날짜가 있을 때만 쿼리 실행
+  });
+};

--- a/next_migration/src/hooks/useSignal.ts
+++ b/next_migration/src/hooks/useSignal.ts
@@ -1,0 +1,75 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import {
+  GetWeeklyActionCountParams,
+  SignalAPIResponse,
+  WeeklyActionCountResponse,
+} from "../types/signal";
+import { signalApiService } from "@/services/signalService";
+
+export const SIGNAL_KEYS = {
+  all: ["signals"] as const,
+  lists: () => [...SIGNAL_KEYS.all, "list"] as const,
+  listByDate: (date: string) => [...SIGNAL_KEYS.lists(), { date }] as const,
+  weeklyActionCount: (params: GetWeeklyActionCountParams) =>
+    [...SIGNAL_KEYS.all, "weeklyActionCount", params] as const,
+};
+
+/**
+ * 특정 날짜의 시그널 데이터를 가져오는 커스텀 훅
+ * @param date 조회할 날짜 (YYYY-MM-DD 형식)
+ * @param options React Query 옵션 (예: enabled)
+ */
+export const useSignalDataByDate = (
+  date: string,
+  options?: Omit<
+    UseQueryOptions<SignalAPIResponse, Error>,
+    "queryKey" | "queryFn"
+  > // React Query 옵션 타입
+) => {
+  return useQuery<SignalAPIResponse, Error>({
+    queryKey: SIGNAL_KEYS.listByDate(date),
+    queryFn: () => signalApiService.getSignalsByDate(date),
+    ...options,
+    enabled: !!date && (options?.enabled === undefined || options.enabled), // 날짜가 있고, enabled 옵션이 true일 때만 실행
+  });
+};
+
+export const useSignalDataByNameAndDate = (
+  symbols: string[],
+  date: string,
+  strategy_type?: string | null,
+  options?: Omit<
+    UseQueryOptions<SignalAPIResponse, Error>,
+    "queryKey" | "queryFn"
+  > // React Query 옵션 타입
+) => {
+  return useQuery<SignalAPIResponse, Error>({
+    queryKey: [
+      ...SIGNAL_KEYS.all,
+      "byNameAndDate",
+      symbols.join(","),
+      date,
+      strategy_type,
+    ],
+    queryFn: () =>
+      signalApiService.getSignalByNameAndDate(symbols, date, strategy_type),
+    ...options,
+    enabled: !!date && (options?.enabled === undefined || options.enabled), // 심볼과 날짜가 모두 있고, enabled 옵션이 true일 때만 실행
+  });
+};
+
+export const useWeeklyActionCount = (
+  params: GetWeeklyActionCountParams,
+  options?: Omit<
+    UseQueryOptions<WeeklyActionCountResponse, Error>,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery<WeeklyActionCountResponse, Error>({
+    queryKey: SIGNAL_KEYS.weeklyActionCount(params),
+    queryFn: () => signalApiService.getWeeklyActionCount(params),
+    ...options,
+    enabled:
+      !!params.action && (options?.enabled === undefined || options.enabled),
+  });
+};

--- a/next_migration/src/hooks/useSignalSearchParams.tsx
+++ b/next_migration/src/hooks/useSignalSearchParams.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from "react";
+
+import { useSearchParams, useRouter } from "next/navigation";
+
+export interface SignalQueryParams {
+  date: string | null;
+  signalId: string | null;
+  q: string | null;
+  models: string[];
+  /**
+   * Conditions between each selected AI model. The length should be
+   * `models.length - 1`. If empty, defaults to all "OR".
+   */
+  conditions: ("OR" | "AND")[];
+  page: string | null; // 페이지 번호
+  pageSize: string | null; // 페이지 크기
+  strategy_type: string | null; // 전략 타입 추가
+}
+
+interface SignalSearchParamsContextValue extends SignalQueryParams {
+  setParams: (updates: Partial<SignalQueryParams>) => void;
+}
+
+const SignalSearchParamsContext =
+  createContext<SignalSearchParamsContextValue | null>(null);
+
+export function SignalSearchParamsProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const params: SignalQueryParams = useMemo(() => {
+    const modelsParam = searchParams.get("models");
+    const conditionParam = searchParams.get("condition");
+    const parsedConditions = conditionParam
+      ? conditionParam
+          .split(",")
+          .filter(Boolean)
+          .map((c) => (c === "AND" ? "AND" : "OR"))
+      : [];
+    return {
+      date: searchParams.get("date"),
+      signalId: searchParams.get("signalId"),
+      q: searchParams.get("q"),
+      models: modelsParam ? modelsParam.split(",").filter(Boolean) : [],
+      conditions: parsedConditions,
+      page: searchParams.get("page"),
+      pageSize: searchParams.get("pageSize"),
+      strategy_type: searchParams.get("strategy_type"), // strategy_type 추가
+    };
+  }, [searchParams]);
+
+  const setParams = useCallback(
+    (updates: Partial<SignalQueryParams>) => {
+      const newParams = new URLSearchParams(searchParams.toString());
+      const apply = (key: string, value: unknown) => {
+        if (
+          value === undefined ||
+          value === null ||
+          value === "" ||
+          (Array.isArray(value) && value.length === 0)
+        ) {
+          newParams.delete(key);
+        } else if (Array.isArray(value)) {
+          newParams.set(key, value.join(","));
+        } else {
+          newParams.set(key, String(value));
+        }
+      };
+
+      if (Object.prototype.hasOwnProperty.call(updates, "date")) {
+        apply("date", updates.date);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, "signalId")) {
+        apply("signalId", updates.signalId);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, "q")) {
+        apply("q", updates.q);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, "models")) {
+        apply("models", updates.models);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, "conditions")) {
+        apply("condition", updates.conditions);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, "page")) {
+        apply("page", updates.page);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, "pageSize")) {
+        apply("pageSize", updates.pageSize);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, "strategy_type")) {
+        apply("strategy_type", updates.strategy_type);
+      }
+
+      if (newParams.toString() !== searchParams.toString()) {
+        router.replace('?' + newParams.toString());
+      }
+    },
+    [searchParams, router]
+  );
+
+  useEffect(() => {
+    if (!params.date) {
+      const today = new Date();
+      const formattedDate = today.toISOString().split("T")[0];
+      setParams({
+        date: formattedDate,
+      });
+    }
+    if (!params.signalId) {
+      setParams({ signalId: null });
+    }
+    if (!params.q) {
+      setParams({ q: null });
+    }
+    if (params.models.length <= 1) {
+      if (params.conditions.length > 0) {
+        setParams({ conditions: [] });
+      }
+    } else {
+      if (params.conditions.length !== params.models.length - 1) {
+        const fill = params.conditions[0] ?? "OR";
+        const newConds = Array(params.models.length - 1).fill(fill);
+        params.conditions.forEach((c, idx) => {
+          if (idx < newConds.length) newConds[idx] = c;
+        });
+        setParams({ conditions: newConds });
+      }
+    }
+    if (params.page === null) {
+      setParams({ page: "0" });
+    }
+    if (params.pageSize === null) {
+      setParams({ pageSize: "20" });
+    }
+    if (params.strategy_type === null) {
+      setParams({ strategy_type: null });
+    }
+  }, [
+    params.conditions.join(','),
+    params.date,
+    params.models.length,
+    params.q,
+    params.signalId,
+    params.page,
+    params.pageSize,
+    params.strategy_type,
+    setParams,
+  ]);
+
+  const value = useMemo(() => ({ ...params, setParams }), [params, setParams]);
+
+  return (
+    <SignalSearchParamsContext.Provider value={value}>
+      {children}
+    </SignalSearchParamsContext.Provider>
+  );
+}
+
+export function useSignalSearchParams() {
+  const ctx = useContext(SignalSearchParamsContext);
+  if (!ctx) {
+    throw new Error(
+      "useSignalSearchParams must be used within SignalSearchParamsProvider"
+    );
+  }
+  return ctx;
+}

--- a/next_migration/src/hooks/useTicker.ts
+++ b/next_migration/src/hooks/useTicker.ts
@@ -1,0 +1,138 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseQueryOptions,
+} from "@tanstack/react-query";
+import {
+  TickerCreate,
+  TickerUpdate,
+  TickerMultiDateQuery,
+  GetWeeklyPriceMovementParams,
+  WeeklyPriceMovementResponse,
+} from "../types/ticker";
+import { tickerService } from "../services/tickerService";
+
+// 쿼리 키 상수
+export const TICKER_KEYS = {
+  all: ["tickers"] as const,
+  lists: () => [...TICKER_KEYS.all, "list"] as const,
+  list: (filters: string) => [...TICKER_KEYS.lists(), { filters }] as const,
+  details: () => [...TICKER_KEYS.all, "detail"] as const,
+  detail: (id: number) => [...TICKER_KEYS.details(), id] as const,
+  bySymbol: (symbol: string) =>
+    [...TICKER_KEYS.details(), "symbol", symbol] as const,
+  byDate: (symbol: string, date: string) =>
+    [...TICKER_KEYS.details(), "date", symbol, date] as const,
+  weeklyPriceMovement: (params: GetWeeklyPriceMovementParams) =>
+    [...TICKER_KEYS.all, "weeklyPriceMovement", params] as const,
+};
+
+// Custom Hooks
+export const useTickers = () => {
+  return useQuery({
+    queryKey: TICKER_KEYS.lists(),
+    queryFn: tickerService.getAllTickers,
+  });
+};
+
+export const useTickerById = (tickerId: number) => {
+  return useQuery({
+    queryKey: TICKER_KEYS.detail(tickerId),
+    queryFn: () => tickerService.getTickerById(tickerId),
+    enabled: !!tickerId, // ID가 있을 때만 쿼리 실행
+  });
+};
+
+export const useTickerBySymbol = (symbol: string) => {
+  return useQuery({
+    queryKey: TICKER_KEYS.bySymbol(symbol),
+    queryFn: () => tickerService.getTickerBySymbol(symbol),
+    enabled: !!symbol, // 심볼이 있을 때만 쿼리 실행
+  });
+};
+
+export const useTickerByDate = (symbol: string, date: string) => {
+  return useQuery({
+    queryKey: TICKER_KEYS.byDate(symbol, date),
+    queryFn: () => tickerService.getTickerByDate(symbol, date),
+    enabled: !!symbol && !!date, // 심볼과 날짜가 모두 있을 때만 쿼리 실행
+  });
+};
+
+export const useTickerChanges = (query: TickerMultiDateQuery | undefined) => {
+  return useQuery({
+    queryKey: [
+      ...TICKER_KEYS.details(),
+      "changes",
+      query?.symbol,
+      query?.dates,
+    ],
+    queryFn: () => tickerService.getTickerChanges(query!),
+    enabled: !!query && !!query.symbol && query.dates.length > 0, // 필수 데이터가 있을 때만 쿼리 실행
+  });
+};
+
+// Mutation Hooks
+export const useCreateTicker = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (newTicker: TickerCreate) =>
+      tickerService.createTicker(newTicker),
+    onSuccess: () => {
+      // 성공 시 티커 목록 쿼리 무효화 (새로고침)
+      queryClient.invalidateQueries({ queryKey: TICKER_KEYS.lists() });
+    },
+  });
+};
+
+export const useUpdateTicker = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      tickerId,
+      tickerData,
+    }: {
+      tickerId: number;
+      tickerData: TickerUpdate;
+    }) => tickerService.updateTicker(tickerId, tickerData),
+    onSuccess: (updatedTicker) => {
+      // 성공 시 해당 티커와 목록 쿼리 무효화
+      queryClient.invalidateQueries({
+        queryKey: TICKER_KEYS.detail(updatedTicker.id),
+      });
+      queryClient.invalidateQueries({ queryKey: TICKER_KEYS.lists() });
+    },
+  });
+};
+
+export const useDeleteTicker = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (tickerId: number) => tickerService.deleteTicker(tickerId),
+    onSuccess: (_, tickerId) => {
+      // 성공 시 해당 티커와 목록 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: TICKER_KEYS.detail(tickerId) });
+      queryClient.invalidateQueries({ queryKey: TICKER_KEYS.lists() });
+    },
+  });
+};
+
+export const useWeeklyPriceMovement = (
+  params: GetWeeklyPriceMovementParams,
+  options?: Omit<
+    UseQueryOptions<WeeklyPriceMovementResponse, Error>,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery<WeeklyPriceMovementResponse, Error>({
+    queryKey: TICKER_KEYS.weeklyPriceMovement(params),
+    queryFn: () => tickerService.getWeeklyPriceMovement(params),
+    ...options,
+    enabled:
+      !!params.direction && (options?.enabled === undefined || options.enabled),
+  });
+};

--- a/next_migration/src/services/newsService.ts
+++ b/next_migration/src/services/newsService.ts
@@ -1,0 +1,73 @@
+import axios from "axios";
+import {
+  GetMarketNewsSummaryRequestParams,
+  MarketForeCastRequestParams,
+  MarketForecastResponse,
+  MarketNewsResponse,
+} from "@/types/news";
+import {
+  GetNewsRecommendationsParams,
+  NewsRecommendationsResponse,
+} from "@/types/news";
+
+const API_BASE_URL =
+  process.env.NODE_ENV === "development"
+    ? process.env.NEXT_PUBLIC_API_LOCAL_URL
+    : process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
+
+const api = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+export const newsService = {
+  async getMarketNewsSummary({
+    news_type,
+    ticker,
+    news_date,
+  }: GetMarketNewsSummaryRequestParams): Promise<MarketNewsResponse> {
+    const url = "/news/";
+    const params = {
+      news_type,
+      ticker,
+      news_date,
+    };
+    const response = await api.get<MarketNewsResponse>(url, { params });
+    return response.data;
+  },
+
+  async getNewsRecommendations({
+    recommendation,
+    limit = 5,
+    date,
+  }: GetNewsRecommendationsParams): Promise<NewsRecommendationsResponse> {
+    const params: Record<string, string | number> = {
+      recommendation,
+      limit,
+    };
+
+    if (date) {
+      params.date = date;
+    }
+
+    const response = await api.get<NewsRecommendationsResponse>(
+      "/news/recommendations",
+      { params }
+    );
+    return response.data;
+  },
+
+  async getMarketForecast({
+    date,
+    source = "Major",
+  }: MarketForeCastRequestParams) {
+    const response = await api.get<MarketForecastResponse[]>(
+      "/news/market-forecast",
+      { params: { forecast_date: date, source: source } }
+    );
+
+    return response.data;
+  },
+};

--- a/next_migration/src/services/signalService.ts
+++ b/next_migration/src/services/signalService.ts
@@ -1,0 +1,79 @@
+import axios from "axios";
+import {
+  GetWeeklyActionCountParams,
+  SignalAPIResponse,
+  WeeklyActionCountResponse,
+} from "../types/signal";
+
+// API 기본 URL 설정 (기존 tickerService.ts와 동일하게 환경 변수 사용)
+const API_BASE_URL =
+  process.env.NODE_ENV === "development"
+    ? process.env.NEXT_PUBLIC_API_LOCAL_URL
+    : process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
+
+// Axios 인스턴스 생성
+const api = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+export const signalApiService = {
+  /**
+   * 특정 날짜의 시그널 데이터를 가져옵니다.
+   * @param date 조회할 날짜 (YYYY-MM-DD 형식)
+   */
+  getSignalsByDate: async (date: string): Promise<SignalAPIResponse> => {
+    // 실제 API 엔드포인트에 맞게 URL을 수정해야 합니다.
+    // 예시: /signals?date=${date} 또는 /signals/${date}
+    // 현재 제공된 응답은 특정 날짜에 대한 것이므로, 해당 날짜를 파라미터로 받는다고 가정합니다.
+    // 이 예제에서는 '/signals/by-date' 엔드포인트와 'date' 쿼리 파라미터를 사용합니다.
+    // 실제 API 문서를 확인하여 정확한 엔드포인트와 파라미터를 사용하세요.
+    const response = await api.get<SignalAPIResponse>("/signals/date", {
+      params: { date },
+    });
+
+    return response.data;
+  },
+
+  getSignalByNameAndDate: async (
+    symbols: string[],
+    date: string,
+    strategy_type?: string | null
+  ): Promise<SignalAPIResponse> => {
+    // 특정 시그널 이름과 날짜에 대한 데이터를 가져오는 API 호출
+    const params: {
+      symbols: string;
+      date: string;
+      strategy_type?: string | null;
+    } = {
+      symbols: symbols.join(","),
+      date,
+    };
+
+    if (strategy_type) {
+      params.strategy_type = strategy_type;
+    }
+
+    const response = await api.get<SignalAPIResponse>("/signals/date", {
+      params: params,
+    });
+
+    return response.data;
+  },
+
+  getWeeklyActionCount: async ({
+    tickers,
+    reference_date,
+    action,
+  }: GetWeeklyActionCountParams): Promise<WeeklyActionCountResponse> => {
+    const response = await api.get<WeeklyActionCountResponse>(
+      "/signals/weekly/action-count",
+      {
+        params: { tickers, reference_date, action },
+      }
+    );
+    return response.data;
+  },
+};

--- a/next_migration/src/services/tickerService.ts
+++ b/next_migration/src/services/tickerService.ts
@@ -1,0 +1,100 @@
+import axios from "axios";
+import {
+  Ticker,
+  TickerCreate,
+  TickerUpdate,
+  TickerMultiDateQuery,
+  TickerChangeResponse,
+  GetWeeklyPriceMovementParams,
+  WeeklyPriceMovementResponse,
+} from "../types/ticker";
+
+// API 기본 URL 설정
+const API_BASE_URL =
+  process.env.NODE_ENV === "development"
+    ? process.env.NEXT_PUBLIC_API_LOCAL_URL
+    : process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
+
+// Axios 인스턴스 생성
+const api = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+export const tickerService = {
+  // 1. 티커 ID로 조회
+  getTickerById: async (tickerId: number): Promise<Ticker> => {
+    const response = await api.get<Ticker>(`/tickers/${tickerId}`);
+    return response.data;
+  },
+
+  // 2. 심볼로 티커 조회
+  getTickerBySymbol: async (symbol: string): Promise<Ticker[]> => {
+    const response = await api.get<Ticker[]>(`/tickers/symbol/${symbol}`);
+    return response.data;
+  },
+
+  // 3. 모든 티커 조회
+  getAllTickers: async (): Promise<Ticker[]> => {
+    const response = await api.get<Ticker[]>("/tickers/");
+    return response.data;
+  },
+
+  // 4. 새 티커 생성
+  createTicker: async (tickerData: TickerCreate): Promise<Ticker> => {
+    const response = await api.post<Ticker>("/tickers/", tickerData);
+    return response.data;
+  },
+
+  // 5. 티커 정보 업데이트
+  updateTicker: async (
+    tickerId: number,
+    tickerData: TickerUpdate
+  ): Promise<Ticker> => {
+    const response = await api.put<Ticker>(`/tickers/${tickerId}`, tickerData);
+    return response.data;
+  },
+
+  // 6. 티커 삭제
+  deleteTicker: async (tickerId: number): Promise<{ message: string }> => {
+    const response = await api.delete<{ message: string }>(
+      `/tickers/${tickerId}`
+    );
+    return response.data;
+  },
+
+  // 7. 특정 날짜의 티커 정보 조회
+  getTickerByDate: async (symbol: string, date: string): Promise<Ticker> => {
+    const response = await api.get<Ticker>("/tickers/by-date", {
+      params: { symbol, date },
+    });
+    return response.data;
+  },
+
+  // 8. 날짜별 변화율 조회
+  getTickerChanges: async (
+    query: TickerMultiDateQuery
+  ): Promise<TickerChangeResponse[]> => {
+    const response = await api.post<TickerChangeResponse[]>(
+      "/tickers/changes",
+      query
+    );
+    return response.data;
+  },
+
+  getWeeklyPriceMovement: async ({
+    tickers,
+    reference_date,
+    direction,
+  }: GetWeeklyPriceMovementParams): Promise<WeeklyPriceMovementResponse> => {
+    const response = await api.get<WeeklyPriceMovementResponse>(
+      "/tickers/weekly/price-movement",
+      {
+        params: { tickers, reference_date, direction },
+      }
+    );
+    return response.data;
+  },
+};

--- a/next_migration/src/types/news.ts
+++ b/next_migration/src/types/news.ts
@@ -1,0 +1,58 @@
+export type MarketNewsItem = {
+  ticker: string | null;
+  headline: string;
+  detail_description: string;
+  created_at: string;
+  result_type: "market";
+  id: number;
+  date_yyyymmdd: string;
+  summary: string;
+  recommendation: "Buy" | "Sell" | "Hold" | null;
+};
+
+export interface MarketNewsResponse {
+  result: MarketNewsItem[];
+}
+
+export type GetMarketNewsSummaryRequestParams = {
+  ticker?: string;
+  news_type?: "market" | "ticker";
+  news_date?: string; // YYYY-MM-DD 형식
+};
+
+export type NewsRecommendationItem = {
+  date: string;
+  headline: string;
+  summary: string;
+  detail_description: string;
+  recommendation: "Buy" | "Sell" | "Hold" | null;
+};
+
+export type TickerNewsRecommendation = {
+  ticker: string;
+  news: NewsRecommendationItem[];
+};
+
+export interface NewsRecommendationsResponse {
+  results: TickerNewsRecommendation[];
+}
+
+export type GetNewsRecommendationsParams = {
+  recommendation: "Buy" | "Hold" | "Sell";
+  limit?: number;
+  date?: string; // YYYY-MM-DD 형식
+};
+
+export type MarketForeCastRequestParams = {
+  date: string; // YYYY-MM-DD 형식
+  source?: "Major" | "Minor";
+};
+
+export type MarketForecastResponse = {
+  date_yyyymmdd: string;
+  outlook: "UP" | "DOWN";
+  reason: string;
+  up_percentage?: number; // e.g., '70'
+  created_at?: string; // ISO format string for datetime
+  source?: "Major" | "Minor";
+};

--- a/next_migration/src/types/signal.ts
+++ b/next_migration/src/types/signal.ts
@@ -1,0 +1,72 @@
+export interface ChartPattern {
+  name: string;
+  description: string;
+  pattern_type: "bullish" | "bearish" | "neutral";
+  confidence_level: number; // Confidence level of the pattern detection (0.0 to 1.0)
+}
+
+export interface Signal {
+  ticker: string;
+  strategy?: string | null;
+  entry_price?: number | null;
+  stop_loss?: number | null;
+  take_profit?: number | null;
+  close_price?: number | null;
+  action?: string | null;
+  timestamp?: string | null;
+  probability?: string | null;
+  result_description?: string | null;
+  report_summary?: string | null;
+  ai_model?: string | null;
+  senario?: string | null;
+  good_things?: string | null;
+  bad_things?: string | null;
+  chart_pattern?: ChartPattern | null;
+}
+
+export interface SignalTickerInfo {
+  symbol: string;
+  name?: string | null;
+  price?: number | null;
+  open_price?: number | null;
+  high_price?: number | null;
+  low_price?: number | null;
+  close_price?: number | null;
+  volume?: number | null;
+  ticker_date?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface SignalResult {
+  action: "up" | "down" | "unchanged" | "unknown";
+  is_correct: boolean;
+  price_diff: number;
+}
+
+export interface SignalData {
+  signal: Signal;
+  ticker?: SignalTickerInfo | null;
+  result?: SignalResult | null;
+}
+export interface SignalAPIResponse {
+  date: string;
+  signals: SignalData[];
+}
+
+// 주간 액션 카운트 타입
+export interface WeeklyActionCount {
+  ticker: string;
+  count: number[];
+  date: string[];
+}
+
+export interface WeeklyActionCountResponse {
+  signals: WeeklyActionCount[];
+}
+
+export interface GetWeeklyActionCountParams {
+  tickers?: string;
+  reference_date?: string;
+  action: "Buy" | "Sell";
+}

--- a/next_migration/src/types/ticker.ts
+++ b/next_migration/src/types/ticker.ts
@@ -1,0 +1,45 @@
+export interface Ticker {
+  id: number;
+  symbol: string;
+  name: string;
+  price: number;
+  open_price?: number;
+  high_price?: number;
+  low_price?: number;
+  close_price?: number;
+  volume?: number;
+  date: string;
+}
+
+export type TickerCreate = Omit<Ticker, "id">;
+
+export type TickerUpdate = Partial<TickerCreate>;
+
+export interface TickerMultiDateQuery {
+  symbol: string;
+  dates: string[]; // 'YYYY-MM-DD' 형식
+}
+
+export interface TickerChangeResponse {
+  symbol: string;
+  date: string;
+  price: number;
+  change_percentage: number;
+  // 추가 필요한 정보들
+}
+
+export interface WeeklyPriceMovement {
+  ticker: string;
+  count: number[];
+  date: string[];
+}
+
+export interface WeeklyPriceMovementResponse {
+  tickers: WeeklyPriceMovement[];
+}
+
+export interface GetWeeklyPriceMovementParams {
+  tickers?: string;
+  reference_date?: string;
+  direction: "up" | "down";
+}


### PR DESCRIPTION
## Summary
- port existing React pages into Next.js `app` directory
- migrate router usage to Next.js hooks and `<Link>`
- copy page dependencies such as hooks, services and signal components
- update custom hooks to use `next/navigation` APIs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860949b76fc8328a92b9c4ebdb8e30e