### PR TITLE
Add Next.js layout with query provider

### DIFF
--- a/next_migration/src/app/layout.tsx
+++ b/next_migration/src/app/layout.tsx
@@ -1,73 +1,26 @@
-import { Metadata } from 'next';
-import { Suspense } from 'react';
-
-import '@/app/globals.css';
-import Footer from '@/components/atoms/Footer';
-import ActionToolbar from '@/components/blocks/ActionToolbar';
-import FloatingButtons from '@/components/blocks/FloatingButtons';
-import GoogleAnalytics from '@/components/blocks/GoogleAnalytics';
-import Providers from '@/components/providers/JotaiProvider';
-import ReactQueryProviders from '@/components/providers/ReactQueryProvider';
-import { SiteHeader } from '@/components/site-header';
-import { TailwindIndicator } from '@/components/tailwind-indicator';
-import { ThemeProvider } from '@/components/theme-provider';
-import { Toaster } from '@/components/ui/toaster';
-import { siteConfig, siteMetadata } from '@/config/site';
-import { cn } from '@/lib/utils';
-
+import type { Metadata } from 'next';
+import './globals.css';
 import Freesentation from './fonts';
+import Header from '@/components/header';
+import { SignalSearchParamsProvider } from '@/hooks/useSignalSearchParams';
+import ReactQueryProvider from '@/components/providers/ReactQueryProvider';
 
 export const metadata: Metadata = {
-  title: {
-    default: siteConfig.name,
-    template: `%s - ${siteConfig.name}`,
-  },
-  description: siteConfig.description,
-  // themeColor: [
-  //   { media: '(prefers-color-scheme: light)', color: 'white' },
-  //   { media: '(prefers-color-scheme: dark)', color: 'black' },
-  // ],
-  icons: {
-    icon: '/favicon.ico',
-    shortcut: '/favicon-16x16.png',
-    apple: '/apple-touch-icon.png',
-  },
-  ...siteMetadata,
+  title: 'Stock Predict AI LLM',
+  description: 'Predict stock prices with AI models',
 };
 
-interface RootLayoutProps {
-  children: React.ReactNode;
-  modal: React.ReactNode;
-}
-
-export default function RootLayout({ children, modal }: RootLayoutProps) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <>
-      <html lang='ko' suppressHydrationWarning>
-        <head>
-          <link rel='icon' href='/icon.png' type='image/png' />
-        </head>
-        <body className={cn('min-h-screen w-full bg-muted/50 antialiased', Freesentation.className)}>
-          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS ?? ''} />
-          <Providers>
-            <ReactQueryProviders>
-              <ThemeProvider attribute='class' defaultTheme='system' enableSystem>
-                <Suspense>
-                  <div className='relative flex min-h-screen flex-col'>
-                    <SiteHeader />
-                    <div className='flex-1 dark:bg-zinc-800'>{children}</div>
-                    <Footer />
-                    <Toaster />
-                  </div>
-                  {modal}
-                  <FloatingButtons />
-                </Suspense>
-                <TailwindIndicator />
-              </ThemeProvider>
-            </ReactQueryProviders>
-          </Providers>
-        </body>
-      </html>
-    </>
+    <html lang="en">
+      <body className={Freesentation.className}>
+        <ReactQueryProvider>
+          <SignalSearchParamsProvider>
+            <Header />
+            {children}
+          </SignalSearchParamsProvider>
+        </ReactQueryProvider>
+      </body>
+    </html>
   );
 }

--- a/next_migration/src/components/header.tsx
+++ b/next_migration/src/components/header.tsx
@@ -1,0 +1,58 @@
+'use client'
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { Moon, Sun } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { AlertTitle, DismissibleAlert } from '@/components/ui/alert';
+
+const Header = () => {
+  const [isDarkMode, setIsDarkMode] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      return savedTheme === 'dark';
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  useEffect(() => {
+    if (isDarkMode) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [isDarkMode]);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode((prev) => !prev);
+  };
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <nav className="flex h-16 items-center justify-between px-6">
+        <Link className="flex items-center w-full" href="/">
+          <img src="/favicon.png" className="w-12 h-12" />
+          <span className="text-base font-light">Stock Predict AI LLM</span>
+        </Link>
+        <div className="flex flex-1 items-center justify-end">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleDarkMode}
+            className="cursor-pointer"
+            aria-label="Toggle theme"
+          >
+            {isDarkMode ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+          </Button>
+        </div>
+      </nav>
+      <DismissibleAlert variant="default" className="px-8 rounded-none">
+        <AlertTitle>🎉 Add Nova AI, Perplexity Sonar Pro Model 🎉</AlertTitle>
+      </DismissibleAlert>
+    </header>
+  );
+};
+
+export default Header;

--- a/next_migration/src/components/providers/ReactQueryProvider.tsx
+++ b/next_migration/src/components/providers/ReactQueryProvider.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useState } from 'react';
+
+export default function ReactQueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 5,
+        gcTime: 1000 * 60 * 10,
+      },
+    },
+  }));
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === 'development' && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
+    </QueryClientProvider>
+  );
+}

--- a/next_migration/src/components/ui/alert.tsx
+++ b/next_migration/src/components/ui/alert.tsx
@@ -1,0 +1,121 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react"; // Import X icon for close button
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+interface AlertProps
+  extends React.ComponentProps<"div">,
+    VariantProps<typeof alertVariants> {
+  onClose?: () => void;
+}
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        data-slot="alert"
+        role="alert"
+        className={cn(alertVariants({ variant }), className)}
+        {...props}
+      />
+    );
+  }
+);
+Alert.displayName = "Alert";
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertClose({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<"button"> & {
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+}) {
+  return (
+    <button
+      data-slot="alert-close"
+      className={cn(
+        "absolute cursor-pointer top-2 right-2 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none",
+        className
+      )}
+      onClick={onClick}
+      {...props}
+    >
+      <X className="h-4 w-4" />
+      <span className="sr-only">Close</span>
+    </button>
+  );
+}
+
+// 자동 닫기 기능이 내장된 새 컴포넌트
+function DismissibleAlert({
+  children,
+  onClose,
+  ...props
+}: AlertProps & { children: React.ReactNode }) {
+  const [isVisible, setIsVisible] = React.useState(true);
+
+  const handleClose = React.useCallback(() => {
+    setIsVisible(false);
+    onClose?.();
+  }, [onClose]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <Alert {...props}>
+      {children}
+      <AlertClose onClick={handleClose} className="px-6" />
+    </Alert>
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertClose, DismissibleAlert };

--- a/next_migration/src/hooks/useSignalSearchParams.tsx
+++ b/next_migration/src/hooks/useSignalSearchParams.tsx
@@ -1,0 +1,168 @@
+'use client'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+export interface SignalQueryParams {
+  date: string | null;
+  signalId: string | null;
+  q: string | null;
+  models: string[];
+  conditions: ("OR" | "AND")[];
+  page: string | null;
+  pageSize: string | null;
+  strategy_type: string | null;
+}
+
+interface SignalSearchParamsContextValue extends SignalQueryParams {
+  setParams: (updates: Partial<SignalQueryParams>) => void;
+}
+
+const SignalSearchParamsContext =
+  createContext<SignalSearchParamsContextValue | null>(null);
+
+export function SignalSearchParamsProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const params: SignalQueryParams = useMemo(() => {
+    const modelsParam = searchParams.get('models');
+    const conditionParam = searchParams.get('condition');
+    const parsedConditions = conditionParam
+      ? conditionParam
+          .split(',')
+          .filter(Boolean)
+          .map((c) => (c === 'AND' ? 'AND' : 'OR'))
+      : [];
+    return {
+      date: searchParams.get('date'),
+      signalId: searchParams.get('signalId'),
+      q: searchParams.get('q'),
+      models: modelsParam ? modelsParam.split(',').filter(Boolean) : [],
+      conditions: parsedConditions,
+      page: searchParams.get('page'),
+      pageSize: searchParams.get('pageSize'),
+      strategy_type: searchParams.get('strategy_type'),
+    };
+  }, [searchParams]);
+
+  const setParams = useCallback(
+    (updates: Partial<SignalQueryParams>) => {
+      const newParams = new URLSearchParams(searchParams.toString());
+      const apply = (key: string, value: unknown) => {
+        if (
+          value === undefined ||
+          value === null ||
+          value === '' ||
+          (Array.isArray(value) && value.length === 0)
+        ) {
+          newParams.delete(key);
+        } else if (Array.isArray(value)) {
+          newParams.set(key, value.join(','));
+        } else {
+          newParams.set(key, String(value));
+        }
+      };
+
+      if (Object.prototype.hasOwnProperty.call(updates, 'date')) {
+        apply('date', updates.date);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, 'signalId')) {
+        apply('signalId', updates.signalId);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, 'q')) {
+        apply('q', updates.q);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, 'models')) {
+        apply('models', updates.models);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, 'conditions')) {
+        apply('condition', updates.conditions);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, 'page')) {
+        apply('page', updates.page);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, 'pageSize')) {
+        apply('pageSize', updates.pageSize);
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, 'strategy_type')) {
+        apply('strategy_type', updates.strategy_type);
+      }
+
+      if (newParams.toString() !== searchParams.toString()) {
+        router.replace(`${pathname}?${newParams.toString()}`);
+      }
+    },
+    [searchParams, router, pathname]
+  );
+
+  useEffect(() => {
+    if (!params.date) {
+      const today = new Date();
+      const formattedDate = today.toISOString().split('T')[0];
+      setParams({ date: formattedDate });
+    }
+    if (!params.signalId) {
+      setParams({ signalId: null });
+    }
+    if (!params.q) {
+      setParams({ q: null });
+    }
+    if (params.models.length <= 1) {
+      if (params.conditions.length > 0) {
+        setParams({ conditions: [] });
+      }
+    } else {
+      if (params.conditions.length !== params.models.length - 1) {
+        const fill = params.conditions[0] ?? 'OR';
+        const newConds = Array(params.models.length - 1).fill(fill);
+        params.conditions.forEach((c, idx) => {
+          if (idx < newConds.length) newConds[idx] = c;
+        });
+        setParams({ conditions: newConds });
+      }
+    }
+    if (params.page === null) {
+      setParams({ page: '0' });
+    }
+    if (params.pageSize === null) {
+      setParams({ pageSize: '20' });
+    }
+    if (params.strategy_type === null) {
+      setParams({ strategy_type: null });
+    }
+  }, [
+    params.conditions.join(','),
+    params.date,
+    params.models.length,
+    params.q,
+    params.signalId,
+    params.page,
+    params.pageSize,
+    params.strategy_type,
+    setParams,
+  ]);
+
+  const value = useMemo(() => ({ ...params, setParams }), [params, setParams]);
+
+  return (
+    <SignalSearchParamsContext.Provider value={value}>
+      {children}
+    </SignalSearchParamsContext.Provider>
+  );
+}
+
+export function useSignalSearchParams() {
+  const ctx = useContext(SignalSearchParamsContext);
+  if (!ctx) {
+    throw new Error('useSignalSearchParams must be used within SignalSearchParamsProvider');
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- simplify next app layout
- add React Query provider and header components
- port signal search params hook for Next.js
- include alert UI component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860991ed234832885656ba658b48718