### PR TITLE
Add Prettier config and update ESLint

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ These variables are used by the service layer and SEO utilities.
 - pnpm dev - Starts the development server.
 - pnpm build - Builds the production-ready code.
 - pnpm lint - Runs ESLint to analyze and lint the code.
+- pnpm format - Formats the codebase with Prettier.
 - pnpm preview - Starts the Vite development server in preview mode.
 
 ## 📂 Project Structure

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,12 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   { ignores: ["dist"] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      "next",
+      "next/core-web-vitals",
+    ],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,


### PR DESCRIPTION
## Summary
- extend Next.js eslint rules
- add Prettier config with Tailwind plugin
- document lint and format commands

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860a108a794832880c19de71ee70748