### PR TITLE
Fix Next.js migration UI components

### DIFF
--- a/next_migration/.env.example
+++ b/next_migration/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_API_BASE_URL=https://api.example.com
+NEXT_PUBLIC_API_LOCAL_URL=http://localhost:8000
+NEXT_PUBLIC_SEO_API_BASE_URL=https://api.example.com

--- a/next_migration/src/components/dashboard/DashboardFooter.tsx
+++ b/next_migration/src/components/dashboard/DashboardFooter.tsx
@@ -1,3 +1,4 @@
+"use client";
 const DashboardFooter = () => {
   return (
     <footer className="border-t bg-muted/50 mt-10 py-6 text-sm leading-relaxed">

--- a/next_migration/src/components/dashboard/HeroSection.tsx
+++ b/next_migration/src/components/dashboard/HeroSection.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { TrendingUp, BarChart3, Search, Newspaper, Brain } from "lucide-react";

--- a/next_migration/src/components/main-nav.tsx
+++ b/next_migration/src/components/main-nav.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Image from "next/image";
 import Link from "next/link";
 import * as React from "react";

--- a/next_migration/src/components/news/MarketForcastCard.tsx
+++ b/next_migration/src/components/news/MarketForcastCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";

--- a/next_migration/src/components/news/MarketNewsCarousel.tsx
+++ b/next_migration/src/components/news/MarketNewsCarousel.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useRef, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { MarketNewsItem } from "@/types/news";

--- a/next_migration/src/components/signal/AiModelFilterPanel.tsx
+++ b/next_migration/src/components/signal/AiModelFilterPanel.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/next_migration/src/components/signal/AiModelSelect.tsx
+++ b/next_migration/src/components/signal/AiModelSelect.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useState } from "react";
 import { Check, ChevronsUpDown } from "lucide-react";
 

--- a/next_migration/src/components/signal/DateSelector.tsx
+++ b/next_migration/src/components/signal/DateSelector.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { parseISO, format as formatDate } from "date-fns";
 import { DatePicker } from "@/components/ui/date-picker";
 

--- a/next_migration/src/components/signal/DateSelectorWrapper.tsx
+++ b/next_migration/src/components/signal/DateSelectorWrapper.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
 import { DateSelector } from "./DateSelector";
 import { useEffect, useState } from "react";

--- a/next_migration/src/components/signal/RecommendationByAICard.tsx
+++ b/next_migration/src/components/signal/RecommendationByAICard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { FC } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { format } from "date-fns";

--- a/next_migration/src/components/signal/RecommendationCard.tsx
+++ b/next_migration/src/components/signal/RecommendationCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { FC } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useNewsRecommendations } from "@/hooks/useMarketNews";

--- a/next_migration/src/components/signal/SignalDataTable.tsx
+++ b/next_migration/src/components/signal/SignalDataTable.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import {
   ColumnDef,

--- a/next_migration/src/components/signal/SignalDetailSection.tsx
+++ b/next_migration/src/components/signal/SignalDetailSection.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { SignalDetailView } from "./SignalDetailView";
 import { useEffect, useState } from "react";

--- a/next_migration/src/components/signal/SignalDetailView.tsx
+++ b/next_migration/src/components/signal/SignalDetailView.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,

--- a/next_migration/src/components/signal/SignalListWrapper.tsx
+++ b/next_migration/src/components/signal/SignalListWrapper.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { ColumnDef } from "@tanstack/react-table";
 import { SignalData } from "@/types/signal";
 import { SignalDataTable } from "./SignalDataTable";

--- a/next_migration/src/components/signal/SignalSearchInput.tsx
+++ b/next_migration/src/components/signal/SignalSearchInput.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useState, useMemo } from "react"; // useMemo 추가
 import { Search, Check } from "lucide-react"; // Check 아이콘 추가
 import {

--- a/next_migration/src/components/signal/SummaryTabsCard.tsx
+++ b/next_migration/src/components/signal/SummaryTabsCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 

--- a/next_migration/src/components/signal/WeeklyActionCountCard.tsx
+++ b/next_migration/src/components/signal/WeeklyActionCountCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { FC } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useWeeklyActionCount } from "@/hooks/useSignal";

--- a/next_migration/src/components/signal/WeeklyPriceMovementCard.tsx
+++ b/next_migration/src/components/signal/WeeklyPriceMovementCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { FC } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useWeeklyPriceMovement } from "@/hooks/useTicker";

--- a/next_migration/src/components/site-header.tsx
+++ b/next_migration/src/components/site-header.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { MainNav } from '@/components/main-nav';
 
 import SideNav from './side-nav';

--- a/next_migration/src/components/tailwind-indicator.tsx
+++ b/next_migration/src/components/tailwind-indicator.tsx
@@ -1,3 +1,4 @@
+"use client";
 export function TailwindIndicator() {
   if (process.env.NODE_ENV === "production") return null
 

--- a/next_migration/src/components/ui/alert.tsx
+++ b/next_migration/src/components/ui/alert.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { X } from "lucide-react"; // Import X icon for close button

--- a/next_migration/src/components/ui/avatar.tsx
+++ b/next_migration/src/components/ui/avatar.tsx
@@ -1,3 +1,4 @@
+"use client";
 'use client';
 
 import * as AvatarPrimitive from '@radix-ui/react-avatar';

--- a/next_migration/src/components/ui/badge.tsx
+++ b/next_migration/src/components/ui/badge.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/next_migration/src/components/ui/button.tsx
+++ b/next_migration/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/next_migration/src/components/ui/calendar.tsx
+++ b/next_migration/src/components/ui/calendar.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import {
   ChevronDownIcon,

--- a/next_migration/src/components/ui/card.tsx
+++ b/next_migration/src/components/ui/card.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/next_migration/src/components/ui/checkbox.tsx
+++ b/next_migration/src/components/ui/checkbox.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { CheckIcon } from "lucide-react"

--- a/next_migration/src/components/ui/command.tsx
+++ b/next_migration/src/components/ui/command.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"

--- a/next_migration/src/components/ui/date-picker.tsx
+++ b/next_migration/src/components/ui/date-picker.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { Calendar as CalendarIcon } from "lucide-react";

--- a/next_migration/src/components/ui/drawer.tsx
+++ b/next_migration/src/components/ui/drawer.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 

--- a/next_migration/src/components/ui/dropdown-menu.tsx
+++ b/next_migration/src/components/ui/dropdown-menu.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"

--- a/next_migration/src/components/ui/input.tsx
+++ b/next_migration/src/components/ui/input.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/next_migration/src/components/ui/label.tsx
+++ b/next_migration/src/components/ui/label.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 

--- a/next_migration/src/components/ui/popover.tsx
+++ b/next_migration/src/components/ui/popover.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 

--- a/next_migration/src/components/ui/progress.tsx
+++ b/next_migration/src/components/ui/progress.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react";
 import * as ProgressPrimitive from "@radix-ui/react-progress";
 

--- a/next_migration/src/components/ui/radio-group.tsx
+++ b/next_migration/src/components/ui/radio-group.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
 import { CircleIcon } from "lucide-react"

--- a/next_migration/src/components/ui/select.tsx
+++ b/next_migration/src/components/ui/select.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"

--- a/next_migration/src/components/ui/skeleton.tsx
+++ b/next_migration/src/components/ui/skeleton.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { cn } from "@/lib/utils"
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {

--- a/next_migration/src/components/ui/skeletons.tsx
+++ b/next_migration/src/components/ui/skeletons.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {

--- a/next_migration/src/components/ui/table.tsx
+++ b/next_migration/src/components/ui/table.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/next_migration/src/components/ui/tabs.tsx
+++ b/next_migration/src/components/ui/tabs.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 

--- a/next_migration/src/components/ui/tooltip.tsx
+++ b/next_migration/src/components/ui/tooltip.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 


### PR DESCRIPTION
## Summary
- mark client components in `/next_migration` so shadcn UI works
- provide example env vars

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a91ebaa48328933d5b801b85c863