### PR TITLE
Refactor dashboard to SSR individual sections

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,14 @@
-import DashboardClient from "@/components/dashboard/DashboardClient";
-import { signalApiService } from "@/services/signalService";
-import { newsService } from "@/services/newsService";
-import { cookies } from "next/headers";
 import HeroSection from "@/components/dashboard/HeroSection";
+import { Suspense } from "react";
+import MarketForecastSection from "@/components/dashboard/ssr/MarketForecastSection";
+import WeeklyActionCountSection from "@/components/dashboard/ssr/WeeklyActionCountSection";
+import WeeklyPriceMovementSection from "@/components/dashboard/ssr/WeeklyPriceMovementSection";
+import RecommendationAiSection from "@/components/dashboard/ssr/RecommendationAiSection";
+import RecommendationNewsSection from "@/components/dashboard/ssr/RecommendationNewsSection";
+import MarketNewsSection from "@/components/dashboard/ssr/MarketNewsSection";
+import SignalsSection from "@/components/dashboard/ssr/SignalsSection";
+import { CardSkeleton, CarouselSkeleton } from "@/components/ui/skeletons";
+import DashboardLoading from "@/components/dashboard/DashboardLoading";
 
 export const metadata = {
   title: "Dashboard",
@@ -16,32 +22,47 @@ export default async function DashboardPage({
 }) {
   const today = new Date().toISOString().split("T")[0];
 
-  // searchParams를 비동기적으로 처리
   const params = await searchParams;
   const date = typeof params?.date === "string" ? params.date : today;
-
-  const [initialSignals, initialMarketNews] = await Promise.all([
-    signalApiService.getSignalsByDate(date),
-    newsService.getMarketNewsSummary({ news_type: "market", news_date: date }),
-  ]);
-
-  let initialFavorites: string[] = [];
-  try {
-    const cookiesStore = cookies();
-    const fav = (await cookiesStore).get("favoriteTickers")?.value;
-    if (fav) initialFavorites = JSON.parse(fav);
-  } catch {
-    initialFavorites = [];
-  }
 
   return (
     <>
       <HeroSection />
-      <DashboardClient
-        initialSignals={initialSignals}
-        initialMarketNews={initialMarketNews}
-        initialFavorites={initialFavorites}
-      />
+      <div className="mx-auto max-w-[1500px] space-y-4 p-4 md:p-8">
+        <div className="mb-4 grid grid-cols-[3fr_4fr_4fr] gap-4 max-lg:grid-cols-1">
+          <Suspense
+            fallback={<CardSkeleton titleHeight={6} cardClassName="shadow-none" contentHeight={140} />}
+          >
+            <MarketForecastSection date={date} />
+          </Suspense>
+          <Suspense
+            fallback={<CardSkeleton titleHeight={6} cardClassName="shadow-none" contentHeight={24} />}
+          >
+            <WeeklyActionCountSection date={date} />
+          </Suspense>
+          <Suspense
+            fallback={<CardSkeleton titleHeight={6} cardClassName="shadow-none" contentHeight={24} />}
+          >
+            <WeeklyPriceMovementSection date={date} />
+          </Suspense>
+          <Suspense
+            fallback={<CardSkeleton titleHeight={6} cardClassName="shadow-none" contentHeight={24} />}
+          >
+            <RecommendationAiSection date={date} />
+          </Suspense>
+          <Suspense
+            fallback={<CardSkeleton titleHeight={6} cardClassName="shadow-none" contentHeight={24} />}
+          >
+            <RecommendationNewsSection date={date} />
+          </Suspense>
+        </div>
+        <Suspense fallback={<CarouselSkeleton itemCount={10} />}>
+          <MarketNewsSection date={date} />
+        </Suspense>
+        <Suspense fallback={<DashboardLoading />}> 
+          <SignalsSection date={date} />
+        </Suspense>
+      </div>
     </>
   );
 }

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -30,7 +30,6 @@ import { WeeklyPriceMovementCard } from "@/components/signal/WeeklyPriceMovement
 import RecommendationCard from "@/components/signal/RecommendationCard";
 import { WeeklyActionCountCard } from "@/components/signal/WeeklyActionCountCard";
 import SummaryTabsCard from "@/components/signal/SummaryTabsCard";
-import HeroSection from "@/components/dashboard/HeroSection";
 import DashboardFooter from "@/components/dashboard/DashboardFooter";
 
 interface DashboardClientProps {

--- a/src/components/dashboard/ssr/MarketForecastSection.tsx
+++ b/src/components/dashboard/ssr/MarketForecastSection.tsx
@@ -1,0 +1,20 @@
+import MarketForCastCard from "@/components/news/MarketForcastCard";
+import { newsService } from "@/services/newsService";
+
+interface Props {
+  date: string;
+}
+
+export default async function MarketForecastSection({ date }: Props) {
+  const [majorData, minorData] = await Promise.all([
+    newsService.getMarketForecast({ date, source: "Major" }),
+    newsService.getMarketForecast({ date, source: "Minor" }),
+  ]);
+  return (
+    <MarketForCastCard
+      title="Today Market Forecast"
+      majorData={majorData}
+      minorData={minorData}
+    />
+  );
+}

--- a/src/components/dashboard/ssr/MarketNewsSection.tsx
+++ b/src/components/dashboard/ssr/MarketNewsSection.tsx
@@ -1,0 +1,14 @@
+import { newsService } from "@/services/newsService";
+import { MarketNewsCarousel } from "@/components/news/MarketNewsCarousel";
+
+interface Props {
+  date: string;
+}
+
+export default async function MarketNewsSection({ date }: Props) {
+  const news = await newsService.getMarketNewsSummary({
+    news_type: "market",
+    news_date: date,
+  });
+  return <MarketNewsCarousel items={news.result ?? []} />;
+}

--- a/src/components/dashboard/ssr/RecommendationAiSection.tsx
+++ b/src/components/dashboard/ssr/RecommendationAiSection.tsx
@@ -1,0 +1,16 @@
+import { signalApiService } from "@/services/signalService";
+import RecommendationByAiCard from "@/components/signal/RecommendationByAICard";
+
+interface Props {
+  date: string;
+}
+
+export default async function RecommendationAiSection({ date }: Props) {
+  const data = await signalApiService.getSignalByNameAndDate([], date, "AI_GENERATED");
+  return (
+    <RecommendationByAiCard
+      title="Today Ai's Recommendation"
+      data={data}
+    />
+  );
+}

--- a/src/components/dashboard/ssr/RecommendationNewsSection.tsx
+++ b/src/components/dashboard/ssr/RecommendationNewsSection.tsx
@@ -1,0 +1,22 @@
+import { newsService } from "@/services/newsService";
+import RecommendationCard from "@/components/signal/RecommendationCard";
+
+interface Props {
+  date: string;
+}
+
+export default async function RecommendationNewsSection({ date }: Props) {
+  const data = await newsService.getNewsRecommendations({
+    recommendation: "Buy",
+    limit: 10,
+    date,
+  });
+  return (
+    <RecommendationCard
+      title="Today News Recommendation"
+      recommendation="Buy"
+      badgeColor="bg-green-100 text-green-800"
+      data={data}
+    />
+  );
+}

--- a/src/components/dashboard/ssr/SignalsSection.tsx
+++ b/src/components/dashboard/ssr/SignalsSection.tsx
@@ -1,0 +1,32 @@
+import DashboardClient from "@/components/dashboard/DashboardClient";
+import { signalApiService } from "@/services/signalService";
+import { newsService } from "@/services/newsService";
+import { cookies } from "next/headers";
+
+interface Props {
+  date: string;
+}
+
+export default async function SignalsSection({ date }: Props) {
+  const [initialSignals, initialMarketNews] = await Promise.all([
+    signalApiService.getSignalsByDate(date),
+    newsService.getMarketNewsSummary({ news_type: "market", news_date: date }),
+  ]);
+
+  let initialFavorites: string[] = [];
+  try {
+    const cookiesStore = cookies();
+    const fav = (await cookiesStore).get("favoriteTickers")?.value;
+    if (fav) initialFavorites = JSON.parse(fav);
+  } catch {
+    initialFavorites = [];
+  }
+
+  return (
+    <DashboardClient
+      initialSignals={initialSignals}
+      initialMarketNews={initialMarketNews}
+      initialFavorites={initialFavorites}
+    />
+  );
+}

--- a/src/components/dashboard/ssr/WeeklyActionCountSection.tsx
+++ b/src/components/dashboard/ssr/WeeklyActionCountSection.tsx
@@ -1,0 +1,20 @@
+import { signalApiService } from "@/services/signalService";
+import { WeeklyActionCountCard } from "@/components/signal/WeeklyActionCountCard";
+
+interface Props {
+  date: string;
+}
+
+export default async function WeeklyActionCountSection({ date }: Props) {
+  const data = await signalApiService.getWeeklyActionCount({
+    action: "Buy",
+    reference_date: date,
+  });
+  return (
+    <WeeklyActionCountCard
+      title="Weekly Top Buy Signals"
+      params={{ action: "Buy", reference_date: date }}
+      data={data}
+    />
+  );
+}

--- a/src/components/dashboard/ssr/WeeklyPriceMovementSection.tsx
+++ b/src/components/dashboard/ssr/WeeklyPriceMovementSection.tsx
@@ -1,0 +1,20 @@
+import { tickerService } from "@/services/tickerService";
+import { WeeklyPriceMovementCard } from "@/components/signal/WeeklyPriceMovementCard";
+
+interface Props {
+  date: string;
+}
+
+export default async function WeeklyPriceMovementSection({ date }: Props) {
+  const data = await tickerService.getWeeklyPriceMovement({
+    direction: "up",
+    reference_date: date,
+  });
+  return (
+    <WeeklyPriceMovementCard
+      title="Weekly Top Up Price Movements"
+      params={{ direction: "up", reference_date: date }}
+      data={data}
+    />
+  );
+}

--- a/src/components/news/MarketForcastCard.tsx
+++ b/src/components/news/MarketForcastCard.tsx
@@ -26,9 +26,11 @@ import {
 
 type Props = {
   title?: string;
+  majorData?: MarketForecastResponse[];
+  minorData?: MarketForecastResponse[];
 };
 
-const MarketForCastCard = ({ title }: Props) => {
+const MarketForCastCard = ({ title, majorData, minorData }: Props) => {
   const { date } = useSignalSearchParams();
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -40,12 +42,14 @@ const MarketForCastCard = ({ title }: Props) => {
 
   const majorForecastQuery = useMarketForecast(
     date ?? format(new Date(), "yyyy-MM-dd"),
-    "Major"
+    "Major",
+    { initialData: majorData, enabled: !majorData },
   );
 
   const minorForecastQuery = useMarketForecast(
     date ?? format(new Date(), "yyyy-MM-dd"),
-    "Minor"
+    "Minor",
+    { initialData: minorData, enabled: !minorData },
   );
 
   const majorForecastData = majorForecastQuery.data || [];

--- a/src/components/signal/RecommendationByAICard.tsx
+++ b/src/components/signal/RecommendationByAICard.tsx
@@ -6,15 +6,21 @@ import { Badge } from "@/components/ui/badge";
 import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
 import { CardSkeleton } from "../ui/skeletons";
 import { useSignalDataByNameAndDate } from "@/hooks/useSignal";
+import { SignalAPIResponse } from "@/types/signal";
 
 const RecommendationByAiCard: FC<{
   title: string;
-}> = ({ title }) => {
+  data?: SignalAPIResponse;
+}> = ({ title, data: initialData }) => {
   const { setParams, date } = useSignalSearchParams();
   const { data, isLoading, error } = useSignalDataByNameAndDate(
     [],
     date ? date : format(new Date(), "yyyy-MM-dd"),
     "AI_GENERATED",
+    {
+      initialData,
+      enabled: !initialData,
+    },
   );
 
   const onClickTicker = (ticker: string, model: string) => {

--- a/src/components/signal/RecommendationCard.tsx
+++ b/src/components/signal/RecommendationCard.tsx
@@ -2,6 +2,7 @@
 import { FC } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useNewsRecommendations } from "@/hooks/useMarketNews";
+import { NewsRecommendationsResponse } from "@/types/news";
 import { format } from "date-fns";
 import { Badge } from "@/components/ui/badge";
 import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
@@ -11,13 +12,20 @@ const RecommendationCard: FC<{
   title: string;
   recommendation: "Buy" | "Hold" | "Sell";
   badgeColor: string;
-}> = ({ title, recommendation, badgeColor }) => {
+  data?: NewsRecommendationsResponse;
+}> = ({ title, recommendation, badgeColor, data: initialData }) => {
   const { setParams, date } = useSignalSearchParams();
-  const { data, isLoading, error } = useNewsRecommendations({
-    recommendation,
-    limit: 10,
-    date: date ? date : format(new Date(), "yyyy-MM-dd"),
-  });
+  const { data, isLoading, error } = useNewsRecommendations(
+    {
+      recommendation,
+      limit: 10,
+      date: date ? date : format(new Date(), "yyyy-MM-dd"),
+    },
+    {
+      initialData,
+      enabled: !initialData,
+    },
+  );
 
   const onClickTicker = (ticker: string) => {
     setParams({ signalId: `${ticker}_OPENAI` });

--- a/src/components/signal/WeeklyActionCountCard.tsx
+++ b/src/components/signal/WeeklyActionCountCard.tsx
@@ -11,11 +11,13 @@ import { CardSkeleton } from "../ui/skeletons";
 interface WeeklyActionCountCardProps {
   title: string;
   params: GetWeeklyActionCountParams;
+  data?: WeeklyActionCountResponse;
 }
 
 export const WeeklyActionCountCard: FC<WeeklyActionCountCardProps> = ({
   title,
   params,
+  data: initialData,
 }) => {
   const { setParams } = useSignalSearchParams();
 
@@ -34,6 +36,8 @@ export const WeeklyActionCountCard: FC<WeeklyActionCountCardProps> = ({
           .slice(0, 10),
       };
     },
+    initialData,
+    enabled: !initialData,
   });
 
   const onClickTicker = (ticker: string) => {

--- a/src/components/signal/WeeklyPriceMovementCard.tsx
+++ b/src/components/signal/WeeklyPriceMovementCard.tsx
@@ -11,11 +11,13 @@ import { CardSkeleton } from "../ui/skeletons";
 interface WeeklyPriceMovementCardProps {
   title: string;
   params: GetWeeklyPriceMovementParams;
+  data?: WeeklyPriceMovementResponse;
 }
 
 export const WeeklyPriceMovementCard: FC<WeeklyPriceMovementCardProps> = ({
   title,
   params,
+  data: initialData,
 }) => {
   const { setParams } = useSignalSearchParams();
 
@@ -31,6 +33,8 @@ export const WeeklyPriceMovementCard: FC<WeeklyPriceMovementCardProps> = ({
           .slice(0, 10),
       };
     },
+    initialData,
+    enabled: !initialData,
   });
 
   const onClickTicker = (ticker: string) => {

--- a/src/hooks/useMarketNews.ts
+++ b/src/hooks/useMarketNews.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { newsService } from "@/services/newsService";
 import {
   GetMarketNewsSummaryRequestParams,
@@ -14,11 +14,13 @@ export const MARKET_NEWS_KEYS = {
     [...MARKET_NEWS_KEYS.all, "summary", ticker, newsDate, newsType] as const,
 };
 
-export const useMarketNewsSummary = ({
-  news_type,
-  ticker,
-  news_date,
-}: GetMarketNewsSummaryRequestParams) => {
+export const useMarketNewsSummary = (
+  { news_type, ticker, news_date }: GetMarketNewsSummaryRequestParams,
+  options?: Omit<
+    UseQueryOptions<MarketNewsResponse, Error>,
+    "queryKey" | "queryFn"
+  >,
+) => {
   return useQuery<MarketNewsResponse, Error>({
     queryKey: MARKET_NEWS_KEYS.summary(ticker, news_date, news_type),
     queryFn: () =>
@@ -27,6 +29,7 @@ export const useMarketNewsSummary = ({
         ticker,
         news_date,
       }),
+    ...options,
   });
 };
 
@@ -36,11 +39,13 @@ export const NEWS_RECOMMENDATION_KEYS = {
     [...NEWS_RECOMMENDATION_KEYS.all, recommendation, limit, date] as const,
 };
 
-export const useNewsRecommendations = ({
-  recommendation,
-  limit = 5,
-  date,
-}: GetNewsRecommendationsParams) => {
+export const useNewsRecommendations = (
+  { recommendation, limit = 5, date }: GetNewsRecommendationsParams,
+  options?: Omit<
+    UseQueryOptions<NewsRecommendationsResponse, Error>,
+    "queryKey" | "queryFn"
+  >,
+) => {
   return useQuery<NewsRecommendationsResponse, Error>({
     queryKey: NEWS_RECOMMENDATION_KEYS.by(recommendation, limit, date),
     queryFn: () =>
@@ -49,16 +54,22 @@ export const useNewsRecommendations = ({
         limit,
         date,
       }),
+    ...options,
   });
 };
 
 export const useMarketForecast = (
   date: string,
-  source: MarketForecastResponse["source"]
+  source: MarketForecastResponse["source"],
+  options?: Omit<
+    UseQueryOptions<MarketForecastResponse[], Error>,
+    "queryKey" | "queryFn"
+  >,
 ) => {
   return useQuery<MarketForecastResponse[], Error>({
     queryKey: ["marketForecast", date, source],
     queryFn: () => newsService.getMarketForecast({ date, source }),
-    enabled: !!date, // 날짜가 있을 때만 쿼리 실행
+    enabled: !!date && (options?.enabled === undefined || options.enabled),
+    ...options,
   });
 };


### PR DESCRIPTION
## Summary
- update data hooks to accept query options
- allow dashboard widgets to receive prefetched data
- create server components for dashboard sections
- rewrite dashboard page to stream each section with Suspense

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861eb4499888328aa95f8745008ac4c