### PR TITLE
Add error handling for dashboard and SSR pages

### DIFF
--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="container mx-auto my-10 space-y-4 p-4">
+      <Alert variant="destructive">
+        <AlertTitle>대시보드를 불러오는 중 오류가 발생했습니다.</AlertTitle>
+        <AlertDescription>{error.message}</AlertDescription>
+      </Alert>
+      <Button onClick={() => reset()}>다시 시도</Button>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="ko">
+      <body>
+        <div className="container mx-auto my-10 space-y-4">
+          <Alert variant="destructive">
+            <AlertTitle>예기치 못한 오류가 발생했습니다.</AlertTitle>
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+          <Button onClick={() => reset()}>다시 시도</Button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/components/dashboard/ssr/MarketForecastSection.tsx
+++ b/src/components/dashboard/ssr/MarketForecastSection.tsx
@@ -1,5 +1,6 @@
 import MarketForCastCard from "@/components/news/MarketForcastCard";
 import { newsService } from "@/services/newsService";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const revalidate = 3600;
 
@@ -9,15 +10,31 @@ interface Props {
 }
 
 export default async function MarketForecastSection({ date, title }: Props) {
-  const [majorData, minorData] = await Promise.all([
-    newsService.getMarketForecast({ date, source: "Major" }),
-    newsService.getMarketForecast({ date, source: "Minor" }),
-  ]);
-  return (
-    <MarketForCastCard
-      title={title ?? "Market Forecast"}
-      majorData={majorData}
-      minorData={minorData}
-    />
-  );
+  try {
+    const [majorData, minorData] = await Promise.all([
+      newsService.getMarketForecast({ date, source: "Major" }),
+      newsService.getMarketForecast({ date, source: "Minor" }),
+    ]);
+    return (
+      <MarketForCastCard
+        title={title ?? "Market Forecast"}
+        majorData={majorData}
+        minorData={minorData}
+      />
+    );
+  } catch (error) {
+    console.error("MarketForecastSection error", error);
+    return (
+      <Card className="shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">
+            {title ?? "Market Forecast"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 중 오류가 발생했습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 }

--- a/src/components/dashboard/ssr/MarketNewsSection.tsx
+++ b/src/components/dashboard/ssr/MarketNewsSection.tsx
@@ -1,5 +1,6 @@
 import { newsService } from "@/services/newsService";
 import { MarketNewsCarousel } from "@/components/news/MarketNewsCarousel";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const revalidate = 3600;
 
@@ -8,9 +9,23 @@ interface Props {
 }
 
 export default async function MarketNewsSection({ date }: Props) {
-  const news = await newsService.getMarketNewsSummary({
-    news_type: "market",
-    news_date: date,
-  });
-  return <MarketNewsCarousel items={news.result ?? []} />;
+  try {
+    const news = await newsService.getMarketNewsSummary({
+      news_type: "market",
+      news_date: date,
+    });
+    return <MarketNewsCarousel items={news.result ?? []} />;
+  } catch (error) {
+    console.error("MarketNewsSection error", error);
+    return (
+      <Card className="shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">Market News</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 중 오류가 발생했습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 }

--- a/src/components/dashboard/ssr/RecommendationAiSection.tsx
+++ b/src/components/dashboard/ssr/RecommendationAiSection.tsx
@@ -1,5 +1,6 @@
 import { signalApiService } from "@/services/signalService";
 import RecommendationByAiCard from "@/components/signal/RecommendationByAICard";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const revalidate = 3600;
 
@@ -9,15 +10,31 @@ interface Props {
 }
 
 export default async function RecommendationAiSection({ date, title }: Props) {
-  const data = await signalApiService.getSignalByNameAndDate(
-    [],
-    date,
-    "AI_GENERATED",
-  );
-  return (
-    <RecommendationByAiCard
-      title={title ?? "AI Generated Recommendations"}
-      data={data}
-    />
-  );
+  try {
+    const data = await signalApiService.getSignalByNameAndDate(
+      [],
+      date,
+      "AI_GENERATED",
+    );
+    return (
+      <RecommendationByAiCard
+        title={title ?? "AI Generated Recommendations"}
+        data={data}
+      />
+    );
+  } catch (error) {
+    console.error("RecommendationAiSection error", error);
+    return (
+      <Card className="h-full shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">
+            {title ?? "AI Generated Recommendations"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 중 오류가 발생했습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 }

--- a/src/components/dashboard/ssr/RecommendationNewsSection.tsx
+++ b/src/components/dashboard/ssr/RecommendationNewsSection.tsx
@@ -1,5 +1,6 @@
 import { newsService } from "@/services/newsService";
 import RecommendationCard from "@/components/signal/RecommendationCard";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const revalidate = 3600;
 
@@ -16,17 +17,31 @@ export default async function RecommendationNewsSection({
   recommendation = "Buy",
   badgeColor = "bg-green-100 text-green-800",
 }: Props) {
-  const data = await newsService.getNewsRecommendations({
-    recommendation: "Buy",
-    limit: 10,
-    date,
-  });
-  return (
-    <RecommendationCard
-      title={title}
-      recommendation={recommendation}
-      badgeColor={badgeColor}
-      data={data}
-    />
-  );
+  try {
+    const data = await newsService.getNewsRecommendations({
+      recommendation: "Buy",
+      limit: 10,
+      date,
+    });
+    return (
+      <RecommendationCard
+        title={title}
+        recommendation={recommendation}
+        badgeColor={badgeColor}
+        data={data}
+      />
+    );
+  } catch (error) {
+    console.error("RecommendationNewsSection error", error);
+    return (
+      <Card className="h-full shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 중 오류가 발생했습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 }

--- a/src/components/dashboard/ssr/SignalsSection.tsx
+++ b/src/components/dashboard/ssr/SignalsSection.tsx
@@ -2,6 +2,7 @@ import DashboardClient from "@/components/dashboard/DashboardClient";
 import { signalApiService } from "@/services/signalService";
 import { newsService } from "@/services/newsService";
 import { cookies } from "next/headers";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const revalidate = 3600;
 
@@ -10,24 +11,38 @@ interface Props {
 }
 
 export default async function SignalsSection({ date }: Props) {
-  const [initialSignals, initialMarketNews] = await Promise.all([
-    signalApiService.getSignalsByDate(date),
-    newsService.getMarketNewsSummary({ news_type: "market", news_date: date }),
-  ]);
-
-  let initialFavorites: string[] = [];
   try {
-    const cookiesStore = cookies();
-    const fav = (await cookiesStore).get("favoriteTickers")?.value;
-    if (fav) initialFavorites = JSON.parse(fav);
-  } catch {
-    initialFavorites = [];
-  }
+    const [initialSignals] = await Promise.all([
+      signalApiService.getSignalsByDate(date),
+      newsService.getMarketNewsSummary({ news_type: "market", news_date: date }),
+    ]);
 
-  return (
-    <DashboardClient
-      initialSignals={initialSignals}
-      initialFavorites={initialFavorites}
-    />
-  );
+    let initialFavorites: string[] = [];
+    try {
+      const cookiesStore = cookies();
+      const fav = (await cookiesStore).get("favoriteTickers")?.value;
+      if (fav) initialFavorites = JSON.parse(fav);
+    } catch {
+      initialFavorites = [];
+    }
+
+    return (
+      <DashboardClient
+        initialSignals={initialSignals}
+        initialFavorites={initialFavorites}
+      />
+    );
+  } catch (error) {
+    console.error("SignalsSection error", error);
+    return (
+      <Card className="shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">Signals</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 중 오류가 발생했습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 }

--- a/src/components/dashboard/ssr/WeeklyActionCountSection.tsx
+++ b/src/components/dashboard/ssr/WeeklyActionCountSection.tsx
@@ -1,5 +1,6 @@
 import { signalApiService } from "@/services/signalService";
 import { WeeklyActionCountCard } from "@/components/signal/WeeklyActionCountCard";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const revalidate = 3600;
 
@@ -14,15 +15,31 @@ export default async function WeeklyActionCountSection({
   title,
   action = "Buy",
 }: Props) {
-  const data = await signalApiService.getWeeklyActionCount({
-    action: "Buy",
-    reference_date: date,
-  });
-  return (
-    <WeeklyActionCountCard
-      title={title ?? "Weekly Action Count"}
-      params={{ action: action, reference_date: date }}
-      data={data}
-    />
-  );
+  try {
+    const data = await signalApiService.getWeeklyActionCount({
+      action: "Buy",
+      reference_date: date,
+    });
+    return (
+      <WeeklyActionCountCard
+        title={title ?? "Weekly Action Count"}
+        params={{ action: action, reference_date: date }}
+        data={data}
+      />
+    );
+  } catch (error) {
+    console.error("WeeklyActionCountSection error", error);
+    return (
+      <Card className="shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">
+            {title ?? "Weekly Action Count"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 중 오류가 발생했습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 }

--- a/src/components/dashboard/ssr/WeeklyPriceMovementSection.tsx
+++ b/src/components/dashboard/ssr/WeeklyPriceMovementSection.tsx
@@ -1,5 +1,6 @@
 import { tickerService } from "@/services/tickerService";
 import { WeeklyPriceMovementCard } from "@/components/signal/WeeklyPriceMovementCard";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const revalidate = 3600;
 
@@ -14,15 +15,31 @@ export default async function WeeklyPriceMovementSection({
   title,
   direction = "up",
 }: Props) {
-  const data = await tickerService.getWeeklyPriceMovement({
-    direction: "up",
-    reference_date: date,
-  });
-  return (
-    <WeeklyPriceMovementCard
-      title={title ?? "Weekly Price Movement"}
-      params={{ direction: direction, reference_date: date }}
-      data={data}
-    />
-  );
+  try {
+    const data = await tickerService.getWeeklyPriceMovement({
+      direction: "up",
+      reference_date: date,
+    });
+    return (
+      <WeeklyPriceMovementCard
+        title={title ?? "Weekly Price Movement"}
+        params={{ direction: direction, reference_date: date }}
+        data={data}
+      />
+    );
+  } catch (error) {
+    console.error("WeeklyPriceMovementSection error", error);
+    return (
+      <Card className="shadow-none">
+        <CardHeader>
+          <CardTitle className="font-medium">
+            {title ?? "Weekly Price Movement"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">데이터 로딩 중 오류가 발생했습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add global and dashboard error boundaries
- handle API errors gracefully in dashboard SSR components

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647b9c52fc8328b2a5079f7ae7a358