### PR TITLE
Slim Docker images for lambda

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,20 +1,8 @@
-FROM node:18.18-alpine AS base
+FROM node:18-alpine AS base
 
-# Install dependencies needed for certain node modules
-RUN apk add --no-cache --virtual .gyp python3 make g++ \
-    && apk del .gyp
-    
-RUN apk add --no-cache python3 py3-pip && pip install awscli
-
-RUN apk add --update --no-cache python3 build-base gcc && ln -sf /usr/bin/python3 /usr/bin/python
-
-# Install dependencies only when needed
 FROM base AS deps
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat yarn
 WORKDIR /app
-
-# Install yarn package manager
-RUN apk add --no-cache yarn
 
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
@@ -29,13 +17,15 @@ RUN \
 # Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
+RUN apk add --no-cache python3 py3-pip build-base gcc make g++ \
+    && pip install awscli \
+    && ln -sf /usr/bin/python3 /usr/bin/python
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-
-# ADD Pnpm
 RUN yarn global add pnpm && pnpm run build
+RUN sh ./upload-to-s3.sh
 
-FROM base AS runner
+FROM node:18-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production
@@ -51,8 +41,6 @@ RUN chown nextjs:nodejs .next
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/upload-to-s3.sh ./upload-to-s3.sh
-RUN sh ./upload-to-s3.sh
 
 ### aws-lambda-adapter
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.6.0 /lambda-adapter /opt/extensions/lambda-adapter


### PR DESCRIPTION
## Summary
- remove Python tooling from runtime images
- install Python only in the build stage
- start runtime stages from a clean Node 18 image

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c01530048328ba6c3f9c6599d023