### PR TITLE
Move S3 upload to build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-RUN npm run build
+RUN npm run build \
+    && sh ./upload-to-s3.sh
 
 FROM base AS runner
 WORKDIR /app
@@ -49,8 +50,6 @@ RUN chown nextjs:nodejs .next
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/upload-to-s3.sh ./upload-to-s3.sh
-RUN sh ./upload-to-s3.sh
 
 # Use /tmp/next/cache for storeing all caching
 RUN mkdir -p .next/cache 

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -33,7 +33,8 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 # ADD Pnpm
-RUN yarn global add pnpm && pnpm run build
+RUN yarn global add pnpm && pnpm run build \
+    && sh ./upload-to-s3.sh
 
 FROM base AS runner
 WORKDIR /app
@@ -51,8 +52,6 @@ RUN chown nextjs:nodejs .next
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/upload-to-s3.sh ./upload-to-s3.sh
-RUN sh ./upload-to-s3.sh
 
 ### aws-lambda-adapter
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.6.0 /lambda-adapter /opt/extensions/lambda-adapter


### PR DESCRIPTION
## Summary
- upload assets during build so runtime image can stay slim
- remove S3 upload step from final stage for both Dockerfiles

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c01fd83c8328963d06c8cb3ba25c