### PR TITLE
Fix dashboard metadata and modal detail handling

### DIFF
--- a/src/app/@modal/dashboard/d/[symbol]/page.tsx
+++ b/src/app/@modal/dashboard/d/[symbol]/page.tsx
@@ -1,23 +1,23 @@
-"use client";
 import { SignalDetailView } from "@/components/signal/SignalDetailView";
-import { Suspense, use } from "react";
+import { Suspense } from "react";
 
 export default function ModalPage({
-  searchParams,
   params,
+  searchParams,
 }: {
-  params: Promise<{ symbol: string }>;
-  searchParams: Promise<{ model?: string; date?: string }>;
+  params: { symbol: string };
+  searchParams: { model?: string; date?: string; strategy_type?: string };
 }) {
-  const searchParams_ = use(searchParams);
-  const { model = "OPENAI" } = searchParams_;
-  const params_ = use(params);
-  const { symbol } = params_;
+  const { symbol } = params;
+  const { model = "OPENAI", date } = searchParams;
 
-  const { date = new Date().toISOString().split("T")[0] } = use(searchParams);
   return (
     <Suspense>
-      <SignalDetailView symbol={symbol} aiModel={model} date={date} />
+      <SignalDetailView
+        symbol={symbol}
+        aiModel={model}
+        date={date ?? new Date().toISOString().split("T")[0]}
+      />
     </Suspense>
   );
 }

--- a/src/app/dashboard/d/[symbol]/page.tsx
+++ b/src/app/dashboard/d/[symbol]/page.tsx
@@ -1,27 +1,106 @@
 import SignalDetailPage from "@/components/signal/SignalDetailPage";
 import { Suspense } from "react";
+import type { Metadata } from "next";
+import { signalApiService } from "@/services/signalService";
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: { symbol: string };
+  searchParams: { model?: string; date?: string; strategy_type?: string };
+}): Promise<Metadata> {
+  const today = new Date().toISOString().split("T")[0];
+  const { symbol } = params;
+  const { model = "OPENAI", date = today, strategy_type } = searchParams;
+
+  const baseMetadata: Metadata = {
+    title: `Forecast ${symbol} Prices | ${model} Model`,
+    description: "Forecast US stock prices using AI models and market signals.",
+    keywords: [
+      "stock forecast",
+      "AI prediction",
+      "market signals",
+      "stock analysis",
+      "financial analysis",
+      symbol,
+      model,
+    ],
+    authors: [{ name: "Spam Finance" }],
+    category: "Finance",
+    creator: "Spam Finance Team",
+    publisher: "Spam Finance",
+    robots: "index, follow",
+    alternates: {
+      canonical: `https://stock.bamtoly.com/dashboard/d/${symbol}?model=${model}&date=${date}${strategy_type ? `&strategy_type=${strategy_type}` : ""}`,
+    },
+    openGraph: {
+      title: `Forecast ${symbol} Prices | ${model} Model`,
+      description: "Forecast US stock prices using AI models and market signals.",
+      url: `https://stock.bamtoly.com/dashboard/d/${symbol}?model=${model}&date=${date}`,
+      siteName: "Spam Finance",
+      locale: "ko_KR",
+      type: "website",
+      images: [
+        {
+          url: "https://stock.bamtoly.com/og-image.jpg",
+          width: 1200,
+          height: 630,
+          alt: "Spam Finance Dashboard Preview",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `Forecast ${symbol} Prices | ${model} Model`,
+      description: "Forecast US stock prices using AI models and market signals.",
+      images: ["https://stock.bamtoly.com/twitter-image.jpg"],
+      creator: "@spamfinance",
+    },
+  };
+
+  try {
+    const data = await signalApiService.getSignalByNameAndDate(
+      [symbol],
+      date,
+      strategy_type,
+    );
+    const signal = data.signals.find(
+      (s) => s.signal.ticker === symbol && s.signal.ai_model === model,
+    );
+    if (signal && signal.signal.result_description) {
+      return {
+        ...baseMetadata,
+        description: signal.signal.result_description,
+      };
+    }
+  } catch (error) {
+    console.error("Failed to generate metadata", error);
+  }
+
+  return baseMetadata;
+}
+
+export const revalidate = 3600;
+export const runtime = "edge";
 
 export default async function DetailPage({
   params,
   searchParams,
 }: {
-  params: Promise<{ symbol: string }>;
-  searchParams: Promise<{
-    model?: string;
-    date?: string;
-    strategy_type?: string;
-  }>;
+  params: { symbol: string };
+  searchParams: { model?: string; date?: string; strategy_type?: string };
 }) {
-  const { symbol } = await params;
-  const { model = "OPENAI", date } = await searchParams;
+  const { symbol } = params;
+  const { model = "OPENAI", date } = searchParams;
 
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      {/* <SignalDetailPage
+      <SignalDetailPage
         symbol={symbol}
         aiModel={model}
         date={date ?? new Date().toISOString().split("T")[0]}
-      /> */}
+      />
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- adjust modal detail route to pass params directly
- implement detailed page with metadata generation
- simplify dashboard metadata and remove unused signal detail logic

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686e1e724f9c8328aeb5af7276e1c832