### PR TITLE
Add pagination features

### DIFF
--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -250,6 +250,7 @@ const SignalAnalysisPage: React.FC<DashboardClientProps> = ({
     pageIndex: page - 1,
     pageSize: pageSize,
   };
+  const paginationInfo = signalApiResponse?.pagination;
 
   return (
     <>
@@ -328,6 +329,7 @@ const SignalAnalysisPage: React.FC<DashboardClientProps> = ({
         onRowClick={handleRowClick}
         isLoading={isLoading || !mounted} // 마운트 전에도 로딩 상태로 처리
         pagination={paginationState}
+        paginationInfo={paginationInfo}
         onPaginationChange={handlePaginationChange}
       />
     </>

--- a/src/components/dashboard/ssr/RecommendationAiSection.tsx
+++ b/src/components/dashboard/ssr/RecommendationAiSection.tsx
@@ -10,17 +10,21 @@ interface Props {
 }
 
 export default async function RecommendationAiSection({ date, title }: Props) {
+  const PAGE_SIZE = 10;
   try {
     const data = await signalApiService.getSignalByNameAndDate(
       [],
       date,
       "AI_GENERATED",
+      1,
+      PAGE_SIZE,
     );
 
     return (
       <RecommendationByAiCard
         title={title ?? "AI Generated Recommendations"}
         data={data}
+        pageSize={PAGE_SIZE}
       />
     );
   } catch (error) {

--- a/src/components/signal/RecommendationByAICard.tsx
+++ b/src/components/signal/RecommendationByAICard.tsx
@@ -4,22 +4,31 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { format } from "date-fns";
 import { Badge } from "@/components/ui/badge";
 import { useSignalSearchParams } from "@/hooks/useSignalSearchParams";
-import { useRouter } from "next/navigation";
 import { CardSkeleton } from "../ui/skeletons";
 import { useSignalDataByNameAndDate } from "@/hooks/useSignal";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { SignalAPIResponse } from "@/types/signal";
 import Link from "next/link";
 
 const RecommendationByAiCard: FC<{
   title: string;
   data?: SignalAPIResponse;
-}> = ({ title, data: initialData }) => {
+  pageSize?: number;
+}> = ({ title, data: initialData, pageSize = 10 }) => {
   const { date } = useSignalSearchParams();
+  const [page, setPage] = React.useState(initialData?.pagination.page ?? 1);
 
   const { data, isLoading, error } = useSignalDataByNameAndDate(
     [],
     date ? date : format(new Date(), "yyyy-MM-dd"),
     "AI_GENERATED",
+    page,
+    pageSize,
+    {
+      initialData,
+      keepPreviousData: true,
+    },
   );
 
   if (isLoading) {
@@ -80,6 +89,32 @@ const RecommendationByAiCard: FC<{
             )}
           </div>
         )}
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <span className="text-sm text-muted-foreground">
+            {(() => {
+              const total = data.pagination.total_items;
+              const start = (page - 1) * pageSize + 1;
+              const end = Math.min(page * pageSize, total);
+              return `${start}-${end} / ${total}`;
+            })()}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={!data.pagination.has_previous}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => p + 1)}
+            disabled={!data.pagination.has_next}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/signal/SignalDataTable.tsx
+++ b/src/components/signal/SignalDataTable.tsx
@@ -41,6 +41,7 @@ interface DataTableProps<TData, TValue> {
     pageIndex: number;
     pageSize: number;
   };
+  paginationInfo?: import("@/types/signal").PaginationResponse;
   // 페이지네이션 변경 이벤트 핸들러
   onPaginationChange?: (pageIndex: number, pageSize: number) => void;
 }
@@ -51,6 +52,7 @@ export function SignalDataTable<TData extends SignalData, TValue>({
   onRowClick,
   isLoading,
   pagination,
+  paginationInfo,
   onPaginationChange,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([
@@ -202,7 +204,9 @@ export function SignalDataTable<TData extends SignalData, TValue>({
             {(() => {
               const pageSize = table.getState().pagination.pageSize || 0;
               const pageIndex = table.getState().pagination.pageIndex || 0;
-              const totalRows = table.getFilteredRowModel().rows.length || 0;
+              const totalRows = paginationInfo
+                ? paginationInfo.total_items
+                : table.getFilteredRowModel().rows.length || 0;
               const currentStart = Math.min(
                 pageSize * pageIndex + 1,
                 totalRows,
@@ -257,7 +261,11 @@ export function SignalDataTable<TData extends SignalData, TValue>({
               table.getState().pagination.pageSize,
             )
           }
-          disabled={!table.getCanPreviousPage()}
+          disabled={
+            paginationInfo
+              ? !paginationInfo.has_previous
+              : !table.getCanPreviousPage()
+          }
         >
           <ChevronLeft className="h-4 w-4 transform" />
         </Button>
@@ -272,7 +280,9 @@ export function SignalDataTable<TData extends SignalData, TValue>({
               table.getState().pagination.pageSize,
             )
           }
-          disabled={!table.getCanNextPage()}
+          disabled={
+            paginationInfo ? !paginationInfo.has_next : !table.getCanNextPage()
+          }
         >
           <ChevronRight className="h-4 w-4" />
         </Button>

--- a/src/components/signal/SignalListWrapper.tsx
+++ b/src/components/signal/SignalListWrapper.tsx
@@ -15,6 +15,7 @@ interface SignalListWrapperProps {
     pageIndex: number;
     pageSize: number;
   };
+  paginationInfo?: import("@/types/signal").PaginationResponse;
   // 페이지네이션 변경 이벤트 핸들러 추가
   onPaginationChange?: (pageIndex: number, pageSize: number) => void;
 }
@@ -26,6 +27,7 @@ export function SignalListWrapper({
   isLoading,
   children,
   pagination,
+  paginationInfo,
   onPaginationChange,
 }: PropsWithChildren<SignalListWrapperProps>) {
   return (
@@ -37,6 +39,7 @@ export function SignalListWrapper({
         onRowClick={onRowClick}
         isLoading={isLoading}
         pagination={pagination}
+        paginationInfo={paginationInfo}
         onPaginationChange={onPaginationChange}
       />
     </div>


### PR DESCRIPTION
## Summary
- enable pagination for AI recommendations
- support server pagination metadata in SignalDataTable
- plumb pagination info through SignalListWrapper and DashboardClient

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874f61b3ee4832887571041c9f3aeeb