### PR TITLE
Remove pagination API usage

### DIFF
--- a/src/app/dashboard/d/[symbol]/page.tsx
+++ b/src/app/dashboard/d/[symbol]/page.tsx
@@ -82,7 +82,7 @@ export async function generateMetadata({
       date,
       strategy_type,
     );
-    const signal = data.data.find(
+    const signal = data.signals.find(
       (s) => s.signal.ticker === symbol && s.signal.ai_model === model,
     );
     if (signal && signal.signal.result_description) {

--- a/src/components/signal/RecommendationByAICard.tsx
+++ b/src/components/signal/RecommendationByAICard.tsx
@@ -56,13 +56,13 @@ const RecommendationByAiCard: FC<{
         </CardTitle>
       </CardHeader>
       <CardContent>
-        {data.data.length === 0 ? (
+        {data.signals.length === 0 ? (
           <p className="text-muted-foreground">
             해당 추천 유형의 종목이 없습니다.
           </p>
         ) : (
           <div className="flex flex-wrap gap-2">
-            {data.data.map(
+            {data.signals.map(
               ({ signal: item }, index) =>
                 item.action === "buy" && (
                   <Link

--- a/src/components/signal/SignalDetailContent.tsx
+++ b/src/components/signal/SignalDetailContent.tsx
@@ -81,7 +81,7 @@ export const SignalDetailContent: React.FC<SignalDetailContentProps> = ({
 
   const data = useMemo(() => {
     try {
-      return signals.data?.data.find(
+      return signals.data?.signals.find(
         (value) =>
           value.signal.ai_model === aiModel && value.signal.ticker === symbol,
       );
@@ -89,7 +89,7 @@ export const SignalDetailContent: React.FC<SignalDetailContentProps> = ({
       console.error("Error in useMemo:", error);
       return null;
     }
-  }, [aiModel, signals.data?.data, symbol]);
+  }, [aiModel, signals.data?.signals, symbol]);
 
   const { data: marketNews } = useMarketNewsSummary({
     news_type: "ticker",
@@ -243,7 +243,7 @@ export const SignalDetailContent: React.FC<SignalDetailContentProps> = ({
                 <AiModelSelect
                   options={[
                     ...new Set(
-                      signals.data?.data.map(
+                      signals.data?.signals.map(
                         (signal) => signal.signal.ai_model ?? "",
                       ),
                     ),

--- a/src/components/signal/SignalDetailView.tsx
+++ b/src/components/signal/SignalDetailView.tsx
@@ -85,11 +85,11 @@ export const SignalDetailView: React.FC<SignalDetailViewProps> = ({
   );
 
   const data = useMemo(() => {
-    return signals.data?.data.find(
+    return signals.data?.signals.find(
       (value) =>
         value.signal.ai_model === aiModel && value.signal.ticker === symbol,
     );
-  }, [aiModel, signals.data?.data, symbol]);
+  }, [aiModel, signals.data?.signals, symbol]);
 
   const { data: marketNews } = useMarketNewsSummary({
     news_type: "ticker",
@@ -252,9 +252,9 @@ export const SignalDetailView: React.FC<SignalDetailViewProps> = ({
                 <div className="flex items-center gap-2">
                   <strong>LLM 모델:</strong>
                   <AiModelSelect
-                    options={[
+                  options={[
                       ...new Set(
-                        signals.data?.data.map(
+                        signals.data?.signals.map(
                           (signal) => signal.signal.ai_model ?? "",
                         ),
                       ),

--- a/src/hooks/useSignal.ts
+++ b/src/hooks/useSignal.ts
@@ -1,13 +1,9 @@
-import {
-  useQuery,
-  useInfiniteQuery,
-  UseQueryOptions,
-  UseInfiniteQueryOptions,
-} from "@tanstack/react-query";
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import {
   GetWeeklyActionCountParams,
   SignalAPIResponse,
   WeeklyActionCountResponse,
+  Signal,
 } from "../types/signal";
 import { signalApiService } from "@/services/signalService";
 
@@ -20,52 +16,20 @@ export const SIGNAL_KEYS = {
 };
 
 /**
- * 특정 날짜의 시그널 데이터를 가져오는 커스텀 훅 (무한 스크롤 지원)
+ * 특정 날짜의 시그널 데이터를 가져오는 커스텀 훅
  * @param date 조회할 날짜 (YYYY-MM-DD 형식)
- * @param pageSize 페이지당 항목 수
- * @param options React Query 옵션 (예: enabled)
- */
-export const useInfiniteSignalDataByDate = (
-  date: string,
-  pageSize: number = 20,
-  options?: Omit<
-    UseInfiniteQueryOptions<SignalAPIResponse, Error>,
-    "queryKey" | "queryFn" | "getNextPageParam" | "initialPageParam"
-  >,
-) => {
-  return useInfiniteQuery({
-    queryKey: [...SIGNAL_KEYS.listByDate(date), pageSize],
-    queryFn: ({ pageParam = 0 }) =>
-      signalApiService.getSignalsByDate(date, pageParam as number, pageSize),
-    getNextPageParam: (lastPage) => {
-      if (!lastPage.pagination?.has_next) return undefined;
-      return lastPage.pagination.page + 1;
-    },
-    initialPageParam: 0,
-    ...options,
-    enabled: !!date && (options?.enabled === undefined || options.enabled),
-  });
-};
-
-/**
- * 특정 날짜의 시그널 데이터를 가져오는 커스텀 훅 (기존 페이지네이션)
- * @param date 조회할 날짜 (YYYY-MM-DD 형식)
- * @param page 현재 페이지 번호
- * @param pageSize 페이지당 항목 수
  * @param options React Query 옵션 (예: enabled)
  */
 export const useSignalDataByDate = (
   date: string,
-  page: number = 1,
-  pageSize: number = 20,
   options?: Omit<
     UseQueryOptions<SignalAPIResponse, Error>,
     "queryKey" | "queryFn"
   >,
 ) => {
   return useQuery<SignalAPIResponse, Error>({
-    queryKey: [...SIGNAL_KEYS.listByDate(date), { page, pageSize }],
-    queryFn: () => signalApiService.getSignalsByDate(date, page, pageSize),
+    queryKey: [...SIGNAL_KEYS.listByDate(date)],
+    queryFn: () => signalApiService.getSignalsByDate(date),
     ...options,
     enabled: !!date && (options?.enabled === undefined || options.enabled),
     staleTime: 1000 * 60 * 5, // 5분간 캐시 데이터 사용
@@ -73,52 +37,13 @@ export const useSignalDataByDate = (
 };
 
 /**
- * 심볼과 날짜로 시그널 데이터를 가져오는 커스텀 훅 (무한 스크롤 지원)
+ * 심볼과 날짜로 시그널 데이터를 가져오는 커스텀 훅
  */
-export const useInfiniteSignalDataByNameAndDate = (
-  symbols: string[],
-  date: string,
-  strategy_type?: string | null,
-  pageSize: number = 20,
-  options?: Omit<
-    UseInfiniteQueryOptions<SignalAPIResponse, Error>,
-    "queryKey" | "queryFn" | "getNextPageParam" | "initialPageParam"
-  >,
-) => {
-  return useInfiniteQuery({
-    queryKey: [
-      ...SIGNAL_KEYS.all,
-      "byNameAndDate",
-      symbols.join(","),
-      date,
-      strategy_type,
-      { pageSize },
-    ],
-    queryFn: ({ pageParam = 1 }) =>
-      signalApiService.getSignalByNameAndDate(
-        symbols,
-        date,
-        strategy_type,
-        pageParam as number,
-        pageSize,
-      ),
-    getNextPageParam: (lastPage) => {
-      if (!lastPage.pagination?.has_next) return undefined;
-      return lastPage.pagination.page + 1;
-    },
-    initialPageParam: 1,
-    ...options,
-    enabled: !!date && (options?.enabled === undefined || options.enabled),
-    staleTime: 1000 * 60 * 5, // 5분간 캐시 데이터 사용
-  });
-};
 
 export const useSignalDataByNameAndDate = (
   symbols: string[],
   date: string,
   strategy_type?: string | null,
-  page: number = 1,
-  pageSize: number = 20,
   options?: Omit<
     UseQueryOptions<SignalAPIResponse, Error>,
     "queryKey" | "queryFn"
@@ -131,15 +56,12 @@ export const useSignalDataByNameAndDate = (
       symbols.join(","),
       date,
       strategy_type,
-      { page, pageSize },
     ],
     queryFn: () =>
       signalApiService.getSignalByNameAndDate(
         symbols,
         date,
         strategy_type,
-        page,
-        pageSize,
       ),
     ...options,
     enabled: !!date && (options?.enabled === undefined || options.enabled),
@@ -168,11 +90,11 @@ export const useTranslatedSignalDataByTickerAndDate = (
   date: string,
   strategy_type?: string | null,
   options?: Omit<
-    UseQueryOptions<SignalAPIResponse["data"][0]["signal"][], Error>,
+    UseQueryOptions<Signal[], Error>,
     "queryKey" | "queryFn"
   >,
 ) => {
-  return useQuery<SignalAPIResponse["data"][0]["signal"][], Error>({
+  return useQuery<Signal[], Error>({
     queryKey: [
       ...SIGNAL_KEYS.all,
       "translatedByTickerAndDate",

--- a/src/services/signalService.ts
+++ b/src/services/signalService.ts
@@ -2,6 +2,7 @@ import {
   GetWeeklyActionCountParams,
   SignalAPIResponse,
   WeeklyActionCountResponse,
+  Signal,
 } from "../types/signal";
 import api from "./api";
 
@@ -10,13 +11,9 @@ export const signalApiService = {
    * 특정 날짜의 시그널 데이터를 가져옵니다.
    * @param date 조회할 날짜 (YYYY-MM-DD 형식)
    */
-  getSignalsByDate: async (
-    date: string,
-    page: number = 1,
-    pageSize: number = 20,
-  ): Promise<SignalAPIResponse> => {
+  getSignalsByDate: async (date: string): Promise<SignalAPIResponse> => {
     const response = await api.get<SignalAPIResponse>("/signals/date", {
-      params: { date, page, page_size: pageSize },
+      params: { date },
     });
 
     return response.data;
@@ -26,20 +23,14 @@ export const signalApiService = {
     symbols: string[],
     date: string,
     strategy_type?: string | null,
-    page: number = 1,
-    pageSize: number = 20,
   ): Promise<SignalAPIResponse> => {
     const params: {
       symbols: string;
       date: string;
       strategy_type?: string | null;
-      page: number;
-      page_size: number;
     } = {
       symbols: symbols.join(","),
       date,
-      page,
-      page_size: pageSize,
     };
 
     if (strategy_type) {
@@ -47,7 +38,7 @@ export const signalApiService = {
     }
 
     const response = await api.get<SignalAPIResponse>("/signals/date", {
-      params: params,
+      params,
     });
 
     return response.data;
@@ -96,7 +87,7 @@ export const signalApiService = {
     ticker: string,
     date: string,
     strategy_type?: string | null,
-  ): Promise<SignalAPIResponse["data"][0]["signal"][]> => {
+  ): Promise<Signal[]> => {
     const params: {
       ticker: string;
       date: string;
@@ -110,7 +101,7 @@ export const signalApiService = {
       params.strategy_type = strategy_type;
     }
 
-    const response = await api.get<SignalAPIResponse["data"][0]["signal"][]>(
+    const response = await api.get<Signal[]>(
       "/translate/signals/ticker",
       { params },
     );

--- a/src/types/signal.ts
+++ b/src/types/signal.ts
@@ -50,21 +50,9 @@ export interface SignalData {
   result?: SignalResult | null;
 }
 
-export interface PaginationResponse {
-  page: number;
-  page_size: number;
-  total_items: number;
-  total_pages: number;
-  has_next: boolean;
-  has_previous: boolean;
+export interface SignalAPIResponse {
+  signals: SignalData[];
 }
-
-export interface PaginatedSignalJoinTickerResponse {
-  data: SignalData[];
-  pagination: PaginationResponse;
-}
-
-export type SignalAPIResponse = PaginatedSignalJoinTickerResponse;
 
 // 주간 액션 카운트 타입
 export interface WeeklyActionCount {


### PR DESCRIPTION
## Summary
- update signal types and services for non-paginated API
- simplify hooks to use single page requests
- adapt dashboard and detail components to new API shape

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876de0c4f1483288cdd4d2b95369b39