### PR TITLE
Reset sorting when data updates

### DIFF
--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -232,6 +232,7 @@ const DashboardClient = ({ initialData }: Props) => {
     });
   }, [filteredSignals]);
 
+
   const columns = useMemo(
     () => createColumns(favorites, toggleFavorite),
     [favorites, toggleFavorite],

--- a/src/components/signal/SignalDataTable.tsx
+++ b/src/components/signal/SignalDataTable.tsx
@@ -65,6 +65,15 @@ export function SignalDataTable<TData extends SignalData, TValue>({
     defaultPageSize: 20,
   });
 
+  // Reset sorting whenever the underlying data changes so
+  // newly toggled favorites appear at the top of the list
+  useEffect(() => {
+    setSorting([
+      { desc: true, id: "signal.favorite" },
+      { desc: true, id: "take_profit_buy" },
+    ]);
+  }, [data]);
+
   function onPaginationChange(newPage: number, newPageSize: number) {
     setPageSize(newPageSize);
     setPage(newPage);

--- a/src/components/signal/columns.tsx
+++ b/src/components/signal/columns.tsx
@@ -24,6 +24,7 @@ export const createColumns = (
   {
     id: "signal.favorite",
     accessorKey: "signal.favorite",
+    enableSorting: false,
     header: "",
     cell: ({ row }) => {
       const ticker = row.original.signal.ticker;


### PR DESCRIPTION
## Summary
- reset default favorite sort whenever data changes so toggling favorites moves them to the top
- disable column sorting for the favorite star column

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68787b59301083289e60701725dd09d4